### PR TITLE
add a curableCopy

### DIFF
--- a/common.js
+++ b/common.js
@@ -1,6 +1,7 @@
 import path from 'node:path'
-import fs from 'node:fs'
 import { spawn } from 'node:child_process'
+import fs from 'fs'
+import { cp, readdir, stat } from 'node:fs/promises';
 
 const __dirname = import.meta.dirname;
 
@@ -67,7 +68,7 @@ export const logNoSuchFile = (error) => {
   }
 }
 
-export function meadowLabel(meadow) {
+export function meadowLabel(meadow, index) {
   if (meadow.path) {
     return `"${meadow.path}" (step #${index})`
   } else if (meadow.name) {
@@ -86,8 +87,47 @@ export function fixInstalledPath(filepath) {
 
 export function fixSourceControlPath(filepath) {
   // transform ~/ into ~~/ for safety
+  if (filepath.length && filepath.startsWith(process.env['HOME'])) filepath = "~" + filepath.slice(process.env['HOME'].length)
   if (filepath.length && filepath[0] == `~`) filepath = `~${filepath}`
   return path.join(getValleyDir(), "/meadows", filepath)
+}
+
+export async function curableCopy(
+  fromPath, 
+  toPath
+) {
+  let files = await readdir(fromPath, {
+    recursive: true,
+    withFileTypes: true
+  })
+
+  let operations = []
+
+  for (let file of files) {
+    if (file.isFile() && !['.DS_Store', 'Thumbs.db'].includes(file.name)) {
+      let realFromPath = `${file.parentPath}/${file.name}`
+      let realToPath = toPath + realFromPath.slice(fromPath.length)
+      let operation = { src: realFromPath, dest: realToPath }
+      try {
+        await cp(realFromPath, realToPath)
+        operation.stats = await stat(realToPath)
+      } catch (cpError) {
+        // at this point, we can bail out to the user to cure, or we can attempt some basic cures:
+        // not portable, but apparently neither is node, so this is better than nothing for now
+        try {
+          await bash(`sudo mkdir -p $(dirname '${realToPath}'); sudo cp '${realFromPath}' '${realToPath}'`)
+          operation.stats = await stat(realToPath)
+        } catch (cureError) {
+          console.error('Node copy failed, and attempting to fix it also failed.')
+          console.error(cpError)
+          console.error(cureError)
+        }
+      }
+      operations.push(operation)
+    }
+  }
+
+  return operations
 }
 
 export async function bash(cmd, {

--- a/common.js
+++ b/common.js
@@ -1,7 +1,7 @@
 import path from 'node:path'
 import { spawn } from 'node:child_process'
 import fs from 'fs'
-import { cp, readdir, stat } from 'node:fs/promises';
+import { cp, readdir, stat, statfs } from 'node:fs/promises';
 import { isNotJunk } from 'junk'
 
 const __dirname = import.meta.dirname;
@@ -100,10 +100,20 @@ export async function curableCopy(
     junk = false
   } = {}
 ) {
-  let files = await readdir(fromPath, {
-    recursive: true,
-    withFileTypes: true
-  })
+  let files 
+  let statFromPath = await stat(fromPath)
+  if (statFromPath.isDirectory()) {
+    files = await readdir(fromPath, {
+      recursive: true,
+      withFileTypes: true
+    })
+  } else {
+    files = [{
+      isFile() { return statFromPath.isFile() },
+      parentPath: path.dirname(fromPath),
+      name: path.basename(fromPath)
+    }]
+  }
 
   let operations = []
 

--- a/gather.js
+++ b/gather.js
@@ -2,7 +2,7 @@
 
 import copy from 'recursive-copy'
 import * as fs from 'node:fs'
-import { parseMeadows, meadowLabel } from './common.js'
+import { parseMeadows, meadowLabel, curableCopy } from './common.js'
 import { fixInstalledPath, fixSourceControlPath, logNoSuchFile, buildCopyOptions, runDirectly } from './common.js'
 
 export async function gather() {
@@ -29,7 +29,7 @@ export async function gather() {
 
         if (meadow.path) {
           try {
-            let operations = await copy(
+            let operations = await (meadow.curable ? curableCopy : copy)(
               fixInstalledPath(meadow.path),
               fixSourceControlPath(meadow.path),
               buildCopyOptions(copyOptions, meadow)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "wildflower",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wildflower",
-      "version": "2.0.1",
+      "version": "3.0.0",
       "license": "ISC",
       "dependencies": {
+        "junk": "^4.0.1",
         "recursive-copy": "^2.0.14"
       },
       "bin": {
@@ -145,12 +146,15 @@
       "license": "ISC"
     },
     "node_modules/junk": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/junk/-/junk-1.0.3.tgz",
-      "integrity": "sha512-3KF80UaaSSxo8jVnRYtMKNGFOoVPBdkkVPsw+Ad0y4oxKXPduS6G6iHkrf69yJVff/VAaYXkV42rtZ7daJxU3w==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/junk/-/junk-4.0.1.tgz",
+      "integrity": "sha512-Qush0uP+G8ZScpGMZvHUiRfI0YBWuB3gVBYlI0v0vvOJt5FLicco+IkP0a50LqTTQhmts/m6tP5SWE+USyIvcQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/maximatch": {
@@ -258,6 +262,15 @@
         "promise": "^7.0.1",
         "rimraf": "^2.7.1",
         "slash": "^1.0.0"
+      }
+    },
+    "node_modules/recursive-copy/node_modules/junk": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/junk/-/junk-1.0.3.tgz",
+      "integrity": "sha512-3KF80UaaSSxo8jVnRYtMKNGFOoVPBdkkVPsw+Ad0y4oxKXPduS6G6iHkrf69yJVff/VAaYXkV42rtZ7daJxU3w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/rimraf": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "junk": "^4.0.1",
     "recursive-copy": "^2.0.14"
   }
 }

--- a/sow.js
+++ b/sow.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import copy from 'recursive-copy'
-import { fixInstalledPath, fixSourceControlPath, logNoSuchFile, buildCopyOptions, parseMeadows, runDirectly, meadowLabel } from './common.js'
+import { fixInstalledPath, fixSourceControlPath, logNoSuchFile, buildCopyOptions, parseMeadows, runDirectly, meadowLabel, curableCopy } from './common.js'
 
 export async function sow() {
   const { meadows } = await parseMeadows()
@@ -26,13 +26,12 @@ export async function sow() {
         // We could, if we wanted to get smart, throw files together in a batch, then trigger them asynchronously.
         if (meadow.path) {
           try {
-            let operations = await copy(
+            let operations = await (meadow.curable ? curableCopy : copy)(
               fixSourceControlPath(meadow.path),
               fixInstalledPath(meadow.path),
               buildCopyOptions(copyOptions, meadow)
             )
 
-            // possibly there's a bug where the operation doesn't work
             copiedFiles = operations.map(operation => operation.dest)
 
             console.log(`Copied '${fixSourceControlPath(meadow.path)}' to '${fixInstalledPath(meadow.path)}'`)


### PR DESCRIPTION
Basically, if the user elects to use the curable version they get "curability" (it attempts to use sudo to do the copy, and if it fails, prints the error and continues) at the cost of filtering.

It's not to a place where it could totally replace recursive-copy (mostly because it doesn't do filtering in any meaningful way).