### PR TITLE
per-file gather + sow + new path and diff commands (v3.1.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,53 @@ When combined with paths, both `gather` and `sow` recieve the paths of the final
 }
 ```
 
+## Targeted (per-file) operations
+
+`gather`, `sow`, and the new `diff` accept zero or more path arguments. With no args, they operate on every meadow (wholesale, the original behavior). With one or more args, they operate only on the named paths:
+
+```sh
+# Wholesale (unchanged):
+wildflower gather
+wildflower sow
+
+# Per-file:
+wildflower gather ~/.zshrc
+wildflower gather ~/.config/ghostty
+wildflower sow    ~/.claude/CLAUDE.md
+wildflower diff   ~/.zshrc                 # reports divergence; no mutation
+wildflower diff                            # all meadows
+```
+
+Targeted operations:
+- Skip meadow-level `if` conditions and `meadow.gather()` / `meadow.sow()` callbacks (those are whole-meadow semantics; the user named the file explicitly).
+- Ignore meadow filters when an explicit path is given. Filters exist to restrict wholesale recursion; when a path is named on the CLI, it's gathered/sowed as-is.
+- Preserve symlinks (`expand: false` in both directions).
+
+## `wildflower path`
+
+A pure path-mapping primitive. Given a tracked path in either form, emits the path in the other store:
+
+```sh
+wildflower path ~/.zshrc
+# → /path/to/valley/meadows/~~/.zshrc
+
+wildflower path /path/to/valley/meadows/~~/.zshrc
+# → /Users/you/.zshrc
+```
+
+No I/O beyond reading `meadows.mjs`. Useful as a composable building block: `diff $(wildflower path ~/.zshrc) ~/.zshrc`, or `cp ~/.zshrc "$(wildflower path ~/.zshrc)"`.
+
+Exits non-zero if the path isn't covered by any meadow.
+
+## `wildflower diff`
+
+Reports divergence between live FS and the meadows mirror. Read-only; never mutates. Exit codes:
+- `0` — all checked paths identical
+- `1` — at least one divergence
+- `2` — at least one path not tracked, or other error
+
+Implementation delegates to `diff -rq` per pair.
+
 ## Todo:
 - Add ability for wildflower to run commands 
   - Note that the `sow` step current runs commands, but the `gather` step does not.

--- a/common.js
+++ b/common.js
@@ -96,6 +96,73 @@ export function fixSourceControlPath(filepath) {
   return path.join(getValleyDir(), "/meadows", filepath)
 }
 
+/**
+ * Given a path on disk (live FS or under meadows/), find the meadow
+ * declaration that covers it. Matches by longest prefix so a more specific
+ * meadow wins over a broader parent. Returns { meadow, installed, absolute }
+ * (installed = absolute live-FS root for the meadow; absolute = caller's
+ * path normalized to its live-FS form). Returns null if no meadow covers.
+ */
+export function findMeadowForPath(targetPath, meadows) {
+  const meadowsRoot = path.join(getValleyDir(), 'meadows')
+  let abs = targetPath
+  if (abs.startsWith('~')) abs = fixInstalledPath(abs)
+  abs = path.resolve(abs)
+
+  // If the path is under the meadows/ mirror, map it back to the live FS
+  // equivalent first so the lookup logic is single-pass.
+  if (abs === meadowsRoot || abs.startsWith(meadowsRoot + '/')) {
+    let mirrorRel = abs.slice(meadowsRoot.length).replace(/^\/+/, '')
+    // mirrorRel looks like '~~/.zshrc' — strip one `~` so we have `~/.zshrc`
+    if (mirrorRel.startsWith('~~')) mirrorRel = mirrorRel.slice(1)
+    abs = fixInstalledPath(mirrorRel)
+  }
+
+  let bestMeadow = null
+  let bestInstalled = null
+  let bestLen = -1
+  for (const meadow of meadows) {
+    if (!meadow.path) continue
+    const installed = path.resolve(fixInstalledPath(meadow.path))
+    if (abs === installed || abs.startsWith(installed + '/')) {
+      if (installed.length > bestLen) {
+        bestMeadow = meadow
+        bestInstalled = installed
+        bestLen = installed.length
+      }
+    }
+  }
+  if (!bestMeadow) return null
+  return { meadow: bestMeadow, installed: bestInstalled, absolute: abs }
+}
+
+/**
+ * Bidirectional path mapping. Given any tracked path (live FS form or
+ * meadows-mirror form), return the path in the other store.
+ * Throws if the input isn't covered by any meadow.
+ */
+export async function mapPath(targetPath) {
+  const { meadows } = await parseMeadows()
+  const match = findMeadowForPath(targetPath, meadows)
+  if (!match) {
+    const err = new Error(`path not in meadows.mjs; add it to track: ${targetPath}`)
+    err.code = 'ENOMEADOW'
+    throw err
+  }
+  const meadowsRoot = path.join(getValleyDir(), 'meadows')
+  let abs = targetPath
+  if (abs.startsWith('~')) abs = fixInstalledPath(abs)
+  abs = path.resolve(abs)
+
+  if (abs === meadowsRoot || abs.startsWith(meadowsRoot + '/')) {
+    // input is meadows-side → return live FS path
+    return match.absolute
+  }
+  // input is live FS → return meadow mirror path
+  const rel = match.absolute.slice(match.installed.length)
+  return fixSourceControlPath(match.meadow.path) + rel
+}
+
 export async function curableCopy(
   fromPath,
   toPath,

--- a/diff.js
+++ b/diff.js
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process'
+import * as fs from 'node:fs'
+import { parseMeadows, fixInstalledPath, fixSourceControlPath, findMeadowForPath, runDirectly } from './common.js'
+
+/**
+ * `wildflower diff [<path>...]` — report live FS vs meadows-mirror divergence
+ * for tracked paths. Read-only; never mutates. With no args, diffs every
+ * meadow; with args, diffs only the named paths.
+ *
+ * Implementation note: delegates to `diff -rq` (recursively report differing
+ * files, brief output). diff is universally available across the target hosts
+ * (mac/wsl/termux/stockholm). Exit code aggregates the diff exit codes:
+ *   0 = all paths identical
+ *   1 = at least one divergence (paths or content)
+ *   2 = at least one path not tracked or other error
+ */
+export async function diff(targets = null) {
+  const { meadows } = await parseMeadows()
+
+  let pairs = []
+  if (targets && targets.length > 0) {
+    let resolveErrors = 0
+    for (const target of targets) {
+      const match = findMeadowForPath(target, meadows)
+      if (!match) {
+        console.error(`Skipping '${target}': not in meadows.mjs`)
+        resolveErrors = 1
+        continue
+      }
+      const rel = match.absolute.slice(match.installed.length)
+      pairs.push({
+        live: match.absolute,
+        meadow: fixSourceControlPath(match.meadow.path) + rel,
+      })
+    }
+    if (resolveErrors && pairs.length === 0) {
+      process.exit(2)
+    }
+  } else {
+    for (const meadow of meadows) {
+      if (!meadow.path) continue
+      pairs.push({
+        live: fixInstalledPath(meadow.path),
+        meadow: fixSourceControlPath(meadow.path),
+      })
+    }
+  }
+
+  let aggregateExit = 0
+  for (const { live, meadow } of pairs) {
+    const liveExists = fs.existsSync(live)
+    const meadowExists = fs.existsSync(meadow)
+    if (!liveExists && !meadowExists) {
+      console.log(`Missing on both sides: ${live}`)
+      aggregateExit = Math.max(aggregateExit, 2)
+      continue
+    }
+    if (!liveExists) {
+      console.log(`Only in meadows: ${meadow}`)
+      aggregateExit = Math.max(aggregateExit, 1)
+      continue
+    }
+    if (!meadowExists) {
+      console.log(`Only in live FS: ${live}`)
+      aggregateExit = Math.max(aggregateExit, 1)
+      continue
+    }
+    const { code, out } = await runDiff(live, meadow)
+    if (out.trim()) console.log(out.trimEnd())
+    if (code !== 0) aggregateExit = Math.max(aggregateExit, code)
+  }
+
+  process.exit(aggregateExit)
+}
+
+function runDiff(live, meadow) {
+  return new Promise((resolve) => {
+    const child = spawn('diff', ['-rq', live, meadow], { stdio: ['ignore', 'pipe', 'pipe'] })
+    let out = ''
+    child.stdout.on('data', d => out += d)
+    child.stderr.on('data', d => out += d)
+    child.on('close', code => resolve({ code: code ?? 0, out }))
+  })
+}
+
+if (runDirectly()) await diff(process.argv.slice(2).length > 0 ? process.argv.slice(2) : null)

--- a/gather.js
+++ b/gather.js
@@ -2,11 +2,44 @@
 
 import copy from 'recursive-copy'
 import * as fs from 'node:fs'
-import { parseMeadows, meadowLabel, curableCopy } from './common.js'
+import path from 'node:path'
+import { parseMeadows, meadowLabel, curableCopy, findMeadowForPath } from './common.js'
 import { fixInstalledPath, fixSourceControlPath, logNoSuchFile, buildCopyOptions, runDirectly } from './common.js'
 
-export async function gather() {
+export async function gather(targets = null) {
   const { meadows } = await parseMeadows()
+
+  fs.mkdirSync('./meadows', { recursive: true })
+
+  // Per-file (targeted) mode. Each target is a live FS path or a meadows
+  // mirror path; we resolve to the live FS form and copy just that path.
+  // Per-meadow `if` conditions and `meadow.gather()` callbacks are skipped
+  // because they're whole-meadow semantics; the user named the file
+  // explicitly and we honor that.
+  if (targets && targets.length > 0) {
+    let exitCode = 0
+    for (const target of targets) {
+      const match = findMeadowForPath(target, meadows)
+      if (!match) {
+        console.error(`Skipping '${target}': not in meadows.mjs (add it to track)`)
+        exitCode = 1
+        continue
+      }
+      const rel = match.absolute.slice(match.installed.length)
+      const src = match.absolute
+      const dst = fixSourceControlPath(match.meadow.path) + rel
+      try {
+        fs.mkdirSync(path.dirname(dst), { recursive: true })
+        await copy(src, dst, { dot: true, overwrite: true, expand: false })
+        console.log(`Gathered '${src}' to '${dst}'`)
+      } catch (e) {
+        logNoSuchFile(e)
+        exitCode = 1
+      }
+    }
+    if (exitCode !== 0) process.exitCode = exitCode
+    return
+  }
 
   const copyOptions = {
     dot: true,
@@ -17,8 +50,6 @@ export async function gather() {
       return !(e.includes('node_modules'))
     }
   }
-
-  fs.mkdirSync('./meadows', { recursive: true })
 
   try {
     for (const [index, meadow] of Object.entries(meadows)) {
@@ -68,4 +99,4 @@ export async function gather() {
   // At some point, we should probably add a separate command to clean up files that have been previously committed, but aren't referenced by the meadows.mjs anymore. That would require some thinking so we don't remove files we're skipping on this system, but are referenced in meadows.mjs.
 }
 
-if (runDirectly()) await gather()
+if (runDirectly()) await gather(process.argv.slice(2).length > 0 ? process.argv.slice(2) : null)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wildflower",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "type": "module",
   "description": "an unopinionated tool for managing your dotflowers",
   "main": "wildflower.js",

--- a/path.js
+++ b/path.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+
+import { mapPath, runDirectly } from './common.js'
+
+/**
+ * `wildflower path <target>` — map a tracked path between its live FS form
+ * and its meadows-mirror form. Pure: no I/O beyond reading meadows.mjs.
+ *
+ * Direction is inferred from whether <target> is under the meadows/ tree
+ * or under the live FS (typically $HOME).
+ */
+export async function pathCmd(targets = []) {
+  if (targets.length === 0) {
+    console.error('Error: wildflower path requires at least one path argument')
+    process.exit(2)
+  }
+
+  let exitCode = 0
+  for (const target of targets) {
+    try {
+      const mapped = await mapPath(target)
+      console.log(mapped)
+    } catch (err) {
+      if (err.code === 'ENOMEADOW') {
+        console.error(err.message)
+        exitCode = 1
+      } else {
+        throw err
+      }
+    }
+  }
+  process.exit(exitCode)
+}
+
+if (runDirectly()) await pathCmd(process.argv.slice(2))

--- a/sow.js
+++ b/sow.js
@@ -1,13 +1,44 @@
 #!/usr/bin/env node
 
 import copy from 'recursive-copy'
-import { fixInstalledPath, fixSourceControlPath, logNoSuchFile, buildCopyOptions, parseMeadows, runDirectly, meadowLabel, curableCopy } from './common.js'
+import * as fs from 'node:fs'
+import path from 'node:path'
+import { fixInstalledPath, fixSourceControlPath, logNoSuchFile, buildCopyOptions, parseMeadows, runDirectly, meadowLabel, curableCopy, findMeadowForPath } from './common.js'
 
-export async function sow() {
+export async function sow(targets = null) {
   const { meadows } = await parseMeadows()
 
   if (!meadows) {
     throw new Error("No meadows found! Make sure you're defining it in your meadows.mjs. (e.g. `({ meadows: [...] })`)")
+  }
+
+  // Per-file (targeted) mode. Symmetric to gather's targeted mode: each
+  // target resolves to a meadow, and we copy just the mirror path back to
+  // its live FS location. Meadow `if` conditions and `meadow.sow()` callbacks
+  // are skipped because they're whole-meadow semantics.
+  if (targets && targets.length > 0) {
+    let exitCode = 0
+    for (const target of targets) {
+      const match = findMeadowForPath(target, meadows)
+      if (!match) {
+        console.error(`Skipping '${target}': not in meadows.mjs (add it to track)`)
+        exitCode = 1
+        continue
+      }
+      const rel = match.absolute.slice(match.installed.length)
+      const src = fixSourceControlPath(match.meadow.path) + rel
+      const dst = match.absolute
+      try {
+        fs.mkdirSync(path.dirname(dst), { recursive: true })
+        await copy(src, dst, { dot: true, overwrite: true, expand: false })
+        console.log(`Sowed '${src}' to '${dst}'`)
+      } catch (e) {
+        logNoSuchFile(e)
+        exitCode = 1
+      }
+    }
+    if (exitCode !== 0) process.exitCode = exitCode
+    return
   }
 
   const copyOptions = {
@@ -66,4 +97,4 @@ export async function sow() {
   }
 }
 
-if (runDirectly()) await sow()
+if (runDirectly()) await sow(process.argv.slice(2).length > 0 ? process.argv.slice(2) : null)

--- a/wildflower.js
+++ b/wildflower.js
@@ -3,22 +3,41 @@
 import { sow } from "./sow.js";
 import { gather } from "./gather.js";
 import { till } from "./till.js";
+import { pathCmd } from "./path.js";
+import { diff } from "./diff.js";
 import packageJson from './package.json' with { type: 'json' };
 
 let command = process.argv[2]
+let rest = process.argv.slice(3)
 
 if (command === 'sow') {
-  await sow()
+  await sow(rest.length > 0 ? rest : null)
 } else if (command === 'gather') {
-  await gather()
+  await gather(rest.length > 0 ? rest : null)
 } else if (command === 'till') {
   await till()
-} else if (command === 'version') {
+} else if (command === 'path') {
+  await pathCmd(rest)
+} else if (command === 'diff') {
+  await diff(rest.length > 0 ? rest : null)
+} else if (command === 'version' || command === '--version' || command === '-v') {
   console.log(packageJson.version)
+} else if (command === 'help' || command === '--help' || command === '-h') {
+  console.log(`wildflower ${packageJson.version}
+
+Commands:
+  gather [<path>...]   Copy live FS → meadows. With no args, wholesale.
+  sow    [<path>...]   Copy meadows → live FS. With no args, wholesale.
+  diff   [<path>...]   Report live-vs-meadows divergence. Read-only.
+  path   <path>        Map a tracked path between live FS and meadows form.
+  till                 Initialize a sample meadows.mjs.
+  version              Print version.
+`)
 } else {
   if (!command) {
-    console.error(`Error: Must provide a command: sow, gather, till`)
+    console.error(`Error: Must provide a command: gather, sow, diff, path, till. Use 'wildflower help' for details.`)
   } else {
     console.error(`Error: Unknown command '${command}'!`)
   }
+  process.exit(2)
 }


### PR DESCRIPTION
## Summary

Adds per-file `gather`/`sow`, a new read-only `diff` command, and a new pure `path` mapping primitive. Bumps to v3.1.0 (minor; new CLI surface). Stacks on top of #19 (symlink fix).

### Motivation

Wholesale `gather` is the only capture verb today. That's a problem when multiple actors (or multiple sessions) edit live FS concurrently — a session that runs `wildflower gather` to capture its own edit also captures every other in-flight live edit, including experimental work from sibling sessions that may never be committed. Per-file `gather <path>` solves this by capturing only the named path.

`path` exposes a composable mapping primitive: given a tracked path on either side, emit its counterpart. With this, callers can use plain UNIX tools (`diff`, `cp`, `git diff --no-index`) to inspect or move state, without `gather`/`sow`/`diff` being the only way to act.

`diff` is the obvious read-only verb that was missing from the API.

### New CLI

```sh
# Per-file (new):
wildflower gather ~/.zshrc
wildflower sow    ~/.claude/CLAUDE.md
wildflower diff   ~/.zshrc          # exit 0 = identical, 1 = differ, 2 = not tracked
wildflower diff                     # whole-tree, no args
wildflower path   ~/.zshrc          # → /path/to/valley/meadows/~~/.zshrc
wildflower path   /path/to/valley/meadows/~~/.zshrc  # → /Users/you/.zshrc

# Wholesale (unchanged):
wildflower gather
wildflower sow

# Help (new):
wildflower help
```

### Implementation notes

- `common.js` gains `findMeadowForPath` and `mapPath`, used by all the new entry points.
- Per-file `gather`/`sow` skip meadow `if` conditions and `meadow.gather()`/`meadow.sow()` callbacks — those are whole-meadow semantics; the user named the file explicitly. Meadow filters are also ignored for explicit-path invocations (filters constrain wholesale recursion).
- Symlinks are preserved in both directions (`expand: false`).
- `diff` delegates to `diff -rq` per pair; available across mac/linux/wsl/termux/etc.

### Test plan

- [x] `wildflower version` reports 3.1.0.
- [x] `wildflower help` prints the new command list.
- [x] `wildflower path ~/.zshrc` emits the meadows-mirror path.
- [x] `wildflower path <meadow-form>` emits the live FS form (reverse direction).
- [x] `wildflower path <nested-path-under-directory-meadow>` works.
- [x] `wildflower path <untracked>` exits 1 with the "not in meadows.mjs" message.
- [x] `wildflower gather ~/.zshrc` copies just that path (no other meadows touched per `git status`).
- [x] `wildflower diff ~/.zshrc` returns 0 for an in-sync path.
- [ ] PR-time TODO: validate per-file `sow` and `diff`-with-divergence in a sandboxed scenario (didn't want to perturb real config during dev).