### PR TITLE
Per-file gather: `wildflower gather <path>`

### DIFF
--- a/common.js
+++ b/common.js
@@ -3,6 +3,8 @@ import { spawn } from 'node:child_process'
 import fs from 'fs'
 import { cp, readdir, stat, statfs } from 'node:fs/promises';
 import { isNotJunk } from 'junk'
+import copy from 'recursive-copy'
+import maximatch from 'maximatch'
 
 const __dirname = import.meta.dirname;
 
@@ -96,14 +98,100 @@ export function fixSourceControlPath(filepath) {
   return path.join(getValleyDir(), "/meadows", filepath)
 }
 
+// Evaluate a meadow's filter against a path relative to the meadow root. The
+// filter is recursive-copy's form: an array of globs (`!` negates) or a
+// predicate. No filter means include everything.
+export function matchesFilter(filter, relPath) {
+  if (Array.isArray(filter)) return maximatch([relPath], filter).length > 0
+  if (typeof filter === 'function') return filter(relPath)
+  return true
+}
+
+// Copy a single tracked path (file or subtree) between the live filesystem and
+// its mirror. `direction` is 'gather' (live → mirror) or 'sow' (mirror → live).
+// Finds the meadow that owns the path, honors that meadow's `if` condition and
+// filter, then copies only files under the target — leaving every other tracked
+// file untouched, so concurrent edits to other files don't bleed in.
+export async function copyPath(targetPath, meadows, direction) {
+  const verb = direction === 'gather' ? 'gathered' : 'sown'
+  const abs = path.resolve(fixInstalledPath(targetPath))
+
+  let owner
+  for (const [index, meadow] of Object.entries(meadows)) {
+    if (!meadow.path) continue
+    const root = path.resolve(fixInstalledPath(meadow.path))
+    if (abs === root || abs.startsWith(root + path.sep)) {
+      owner = { index, meadow, root }
+      break
+    }
+  }
+  if (!owner) {
+    console.error(`No meadow in meadows.mjs tracks '${abs}'. Add it, or ${direction} the whole valley.`)
+    process.exit(1)
+  }
+  const { index, meadow, root } = owner
+
+  const shouldRun = meadow.if ? await meadow.if() : true
+  if (!shouldRun) {
+    console.log(`Skipping '${abs}' — ${meadowLabel(meadow, index)} condition didn't pass on this host.`)
+    return
+  }
+
+  // Path of the target relative to the meadow root (posix-style, as the meadow
+  // glob filters expect). Empty when the target IS the meadow root. The mirror
+  // preserves the live tree's layout, so this aligns for both directions.
+  const relTarget = path.relative(root, abs).split(path.sep).join('/')
+  const meadowFilter = meadow.filter
+
+  const options = {
+    dot: true,
+    overwrite: true,
+    expand: false,
+    filter(entry) {
+      const norm = String(entry).split(path.sep).join('/')
+      // Restrict the copy to the target (and the dirs needed to reach it).
+      if (relTarget !== '') {
+        const isTarget = norm === relTarget || norm.startsWith(relTarget + '/')
+        const isAncestorDir = relTarget.startsWith(norm + '/')
+        if (!isTarget && !isAncestorDir) return false
+        // Ancestor dirs only need traversal — skip the meadow filter for them.
+        if (isAncestorDir && !isTarget) return true
+      }
+      // Honor the meadow's own include/exclude filter (e.g. !*-tokens.json).
+      return matchesFilter(meadowFilter, norm)
+    },
+  }
+
+  const from = direction === 'gather' ? fixInstalledPath(meadow.path) : fixSourceControlPath(meadow.path)
+  const to = direction === 'gather' ? fixSourceControlPath(meadow.path) : fixInstalledPath(meadow.path)
+
+  try {
+    const operations = await (meadow.curable ? curableCopy : copy)(from, to, options)
+    const files = operations.filter((op) => op.stats?.isFile?.() ?? true)
+    if (files.length === 0) {
+      console.error(`Nothing ${verb} for '${abs}' — excluded by the ${meadowLabel(meadow, index)} filter?`)
+      process.exit(1)
+    }
+    for (const op of files) {
+      console.log(`Copied '${op.src}' to '${op.dest}'`)
+    }
+  } catch (e) {
+    logNoSuchFile(e)
+  }
+}
+
 export async function curableCopy(
   fromPath,
   toPath,
   {
-    junk = false
+    junk = false,
+    // Mirrors recursive-copy's `filter`: an array of globs (with `!` negation)
+    // or a predicate, both keyed on the path relative to `fromPath`. Honored so
+    // curable meadows respect their include/exclude rules, like non-curable ones.
+    filter
   } = {}
 ) {
-  let files 
+  let files
   let statFromPath = await stat(fromPath)
   if (statFromPath.isDirectory()) {
     files = await readdir(fromPath, {
@@ -124,6 +212,9 @@ export async function curableCopy(
     if (file.isFile()) {
       if (junk === false && isNotJunk(file.name)) {
         let realFromPath = `${file.parentPath}/${file.name}`
+        // Path relative to fromPath (posix, no leading separator), as the filter expects.
+        let rel = realFromPath.slice(fromPath.length).replace(/^[\\/]/, '').split(path.sep).join('/')
+        if (!matchesFilter(filter, rel)) continue
         let realToPath = toPath + realFromPath.slice(fromPath.length)
         let operation = { src: realFromPath, dest: realToPath }
         try {

--- a/gather.js
+++ b/gather.js
@@ -1,10 +1,8 @@
 #!/usr/bin/env node
 
 import copy from 'recursive-copy'
-import maximatch from 'maximatch'
 import * as fs from 'node:fs'
-import * as path from 'node:path'
-import { parseMeadows, meadowLabel, curableCopy } from './common.js'
+import { parseMeadows, meadowLabel, curableCopy, copyPath } from './common.js'
 import { fixInstalledPath, fixSourceControlPath, logNoSuchFile, buildCopyOptions, runDirectly } from './common.js'
 
 export async function gather(targetPath) {
@@ -15,7 +13,7 @@ export async function gather(targetPath) {
   // Without a path, fall through to the wholesale gather below (used by
   // dotfiles-update.sh).
   if (targetPath) {
-    return gatherPath(targetPath, meadows)
+    return copyPath(targetPath, meadows, 'gather')
   }
 
   const copyOptions = {
@@ -76,75 +74,6 @@ export async function gather(targetPath) {
   }
 
   // At some point, we should probably add a separate command to clean up files that have been previously committed, but aren't referenced by the meadows.mjs anymore. That would require some thinking so we don't remove files we're skipping on this system, but are referenced in meadows.mjs.
-}
-
-// Gather a single tracked path (file or subtree) into its mirror. Finds the
-// meadow that owns the path, honors that meadow's `if` condition and filter,
-// then copies only files under the target — leaving every other tracked file
-// in the working tree untouched.
-async function gatherPath(targetPath, meadows) {
-  const abs = path.resolve(fixInstalledPath(targetPath))
-
-  let owner
-  for (const [index, meadow] of Object.entries(meadows)) {
-    if (!meadow.path) continue
-    const root = path.resolve(fixInstalledPath(meadow.path))
-    if (abs === root || abs.startsWith(root + path.sep)) {
-      owner = { index, meadow, root }
-      break
-    }
-  }
-  if (!owner) {
-    console.error(`No meadow in meadows.mjs tracks '${abs}'. Add it, or gather the whole valley.`)
-    process.exit(1)
-  }
-  const { index, meadow, root } = owner
-
-  const shouldGather = meadow.if ? await meadow.if() : true
-  if (!shouldGather) {
-    console.log(`Skipping '${abs}' — ${meadowLabel(meadow, index)} condition didn't pass on this host.`)
-    return
-  }
-
-  // Path of the target relative to the meadow root (posix-style, as the meadow
-  // glob filters expect). Empty when the target IS the meadow root.
-  const relTarget = path.relative(root, abs).split(path.sep).join('/')
-  const meadowFilter = meadow.filter
-
-  const options = {
-    dot: true,
-    overwrite: true,
-    expand: false,
-    filter(entry) {
-      const norm = String(entry).split(path.sep).join('/')
-      // Restrict the copy to the target (and the dirs needed to reach it).
-      if (relTarget !== '') {
-        const isTarget = norm === relTarget || norm.startsWith(relTarget + '/')
-        const isAncestorDir = relTarget.startsWith(norm + '/')
-        if (!isTarget && !isAncestorDir) return false
-        // Ancestor dirs only need traversal — skip the meadow filter for them.
-        if (isAncestorDir && !isTarget) return true
-      }
-      // Honor the meadow's own include/exclude filter (e.g. !*-tokens.json).
-      if (Array.isArray(meadowFilter)) return maximatch([norm], meadowFilter).length > 0
-      if (typeof meadowFilter === 'function') return meadowFilter(entry)
-      return true
-    },
-  }
-
-  try {
-    const operations = await copy(fixInstalledPath(meadow.path), fixSourceControlPath(meadow.path), options)
-    const files = operations.filter((op) => op.stats?.isFile?.() ?? true)
-    if (files.length === 0) {
-      console.error(`Nothing gathered for '${abs}' — excluded by the ${meadowLabel(meadow, index)} filter?`)
-      process.exit(1)
-    }
-    for (const op of files) {
-      console.log(`Copied '${op.src}' to '${op.dest}'`)
-    }
-  } catch (e) {
-    logNoSuchFile(e)
-  }
 }
 
 if (runDirectly()) await gather(process.argv[2])

--- a/gather.js
+++ b/gather.js
@@ -1,12 +1,22 @@
 #!/usr/bin/env node
 
 import copy from 'recursive-copy'
+import maximatch from 'maximatch'
 import * as fs from 'node:fs'
+import * as path from 'node:path'
 import { parseMeadows, meadowLabel, curableCopy } from './common.js'
 import { fixInstalledPath, fixSourceControlPath, logNoSuchFile, buildCopyOptions, runDirectly } from './common.js'
 
-export async function gather() {
+export async function gather(targetPath) {
   const { meadows } = await parseMeadows()
+
+  // Per-file gather: with an explicit path, capture only that file/subtree so
+  // concurrent edits to other tracked files don't bleed into the working tree.
+  // Without a path, fall through to the wholesale gather below (used by
+  // dotfiles-update.sh).
+  if (targetPath) {
+    return gatherPath(targetPath, meadows)
+  }
 
   const copyOptions = {
     dot: true,
@@ -68,4 +78,73 @@ export async function gather() {
   // At some point, we should probably add a separate command to clean up files that have been previously committed, but aren't referenced by the meadows.mjs anymore. That would require some thinking so we don't remove files we're skipping on this system, but are referenced in meadows.mjs.
 }
 
-if (runDirectly()) await gather()
+// Gather a single tracked path (file or subtree) into its mirror. Finds the
+// meadow that owns the path, honors that meadow's `if` condition and filter,
+// then copies only files under the target — leaving every other tracked file
+// in the working tree untouched.
+async function gatherPath(targetPath, meadows) {
+  const abs = path.resolve(fixInstalledPath(targetPath))
+
+  let owner
+  for (const [index, meadow] of Object.entries(meadows)) {
+    if (!meadow.path) continue
+    const root = path.resolve(fixInstalledPath(meadow.path))
+    if (abs === root || abs.startsWith(root + path.sep)) {
+      owner = { index, meadow, root }
+      break
+    }
+  }
+  if (!owner) {
+    console.error(`No meadow in meadows.mjs tracks '${abs}'. Add it, or gather the whole valley.`)
+    process.exit(1)
+  }
+  const { index, meadow, root } = owner
+
+  const shouldGather = meadow.if ? await meadow.if() : true
+  if (!shouldGather) {
+    console.log(`Skipping '${abs}' — ${meadowLabel(meadow, index)} condition didn't pass on this host.`)
+    return
+  }
+
+  // Path of the target relative to the meadow root (posix-style, as the meadow
+  // glob filters expect). Empty when the target IS the meadow root.
+  const relTarget = path.relative(root, abs).split(path.sep).join('/')
+  const meadowFilter = meadow.filter
+
+  const options = {
+    dot: true,
+    overwrite: true,
+    expand: false,
+    filter(entry) {
+      const norm = String(entry).split(path.sep).join('/')
+      // Restrict the copy to the target (and the dirs needed to reach it).
+      if (relTarget !== '') {
+        const isTarget = norm === relTarget || norm.startsWith(relTarget + '/')
+        const isAncestorDir = relTarget.startsWith(norm + '/')
+        if (!isTarget && !isAncestorDir) return false
+        // Ancestor dirs only need traversal — skip the meadow filter for them.
+        if (isAncestorDir && !isTarget) return true
+      }
+      // Honor the meadow's own include/exclude filter (e.g. !*-tokens.json).
+      if (Array.isArray(meadowFilter)) return maximatch([norm], meadowFilter).length > 0
+      if (typeof meadowFilter === 'function') return meadowFilter(entry)
+      return true
+    },
+  }
+
+  try {
+    const operations = await copy(fixInstalledPath(meadow.path), fixSourceControlPath(meadow.path), options)
+    const files = operations.filter((op) => op.stats?.isFile?.() ?? true)
+    if (files.length === 0) {
+      console.error(`Nothing gathered for '${abs}' — excluded by the ${meadowLabel(meadow, index)} filter?`)
+      process.exit(1)
+    }
+    for (const op of files) {
+      console.log(`Copied '${op.src}' to '${op.dest}'`)
+    }
+  } catch (e) {
+    logNoSuchFile(e)
+  }
+}
+
+if (runDirectly()) await gather(process.argv[2])

--- a/sow.js
+++ b/sow.js
@@ -1,13 +1,19 @@
 #!/usr/bin/env node
 
 import copy from 'recursive-copy'
-import { fixInstalledPath, fixSourceControlPath, logNoSuchFile, buildCopyOptions, parseMeadows, runDirectly, meadowLabel, curableCopy } from './common.js'
+import { fixInstalledPath, fixSourceControlPath, logNoSuchFile, buildCopyOptions, parseMeadows, runDirectly, meadowLabel, curableCopy, copyPath } from './common.js'
 
-export async function sow() {
+export async function sow(targetPath) {
   const { meadows } = await parseMeadows()
 
   if (!meadows) {
     throw new Error("No meadows found! Make sure you're defining it in your meadows.mjs. (e.g. `({ meadows: [...] })`)")
+  }
+
+  // Per-file sow: with an explicit path, deploy only that file/subtree from its
+  // mirror. Without a path, fall through to the wholesale sow below.
+  if (targetPath) {
+    return copyPath(targetPath, meadows, 'sow')
   }
 
   const copyOptions = {
@@ -63,4 +69,4 @@ export async function sow() {
   }
 }
 
-if (runDirectly()) await sow()
+if (runDirectly()) await sow(process.argv[2])

--- a/wildflower.js
+++ b/wildflower.js
@@ -10,7 +10,7 @@ let command = process.argv[2]
 if (command === 'sow') {
   await sow()
 } else if (command === 'gather') {
-  await gather()
+  await gather(process.argv[3])
 } else if (command === 'till') {
   await till()
 } else if (command === 'version') {

--- a/wildflower.js
+++ b/wildflower.js
@@ -8,7 +8,7 @@ import packageJson from './package.json' with { type: 'json' };
 let command = process.argv[2]
 
 if (command === 'sow') {
-  await sow()
+  await sow(process.argv[3])
 } else if (command === 'gather') {
   await gather(process.argv[3])
 } else if (command === 'till') {


### PR DESCRIPTION
## Problem

`gather()` ignored its path argument and always copied **every** meadow wholesale, so `wildflower gather <path>` swept in unrelated files (even `gather --help` ran a full gather). The per-file workflow documented elsewhere didn't actually exist.

## Change

- `wildflower.js`: pass `process.argv[3]` into `gather()`.
- `gather.js`: with a path argument, `gatherPath()` resolves the owning meadow, honors that meadow's `if` condition and filter, and copies **only** files under the target — leaving every other tracked file untouched. With no argument, the wholesale loop is unchanged (still used by `dotfiles-update.sh`).

Point `VALLEY_PATH` at a worktree to land the mirror there instead of the main checkout:

```bash
VALLEY_PATH="$PWD" wildflower gather ~/.zshenv   # run from the worktree
```

## Tested

| Case | Result |
| --- | --- |
| `gather ~/.aeby/scripts/cc-cred` | copies only that file |
| `gather ~/.config/cc-allow.toml` (other meadow) | copies only that file |
| `gather ~/.aeby/itad-tokens.json` (excluded by `!*-tokens.json`) | **refused** |
| `gather ~/not-tracked` | clean "No meadow tracks" error |
| `gather` (no arg) | still wholesale |
| working tree after each | clean — zero bleed |
