### PR TITLE
Reconcile per-file CLI: full surface + filter/curable/if correctness (v3.1.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,53 @@ When combined with paths, both `gather` and `sow` recieve the paths of the final
 }
 ```
 
+## Targeted (per-file) operations
+
+`gather`, `sow`, and the new `diff` accept zero or more path arguments. With no args, they operate on every meadow (wholesale, the original behavior). With one or more args, they operate only on the named paths:
+
+```sh
+# Wholesale (unchanged):
+wildflower gather
+wildflower sow
+
+# Per-file:
+wildflower gather ~/.zshrc
+wildflower gather ~/.config/ghostty
+wildflower sow    ~/.claude/CLAUDE.md
+wildflower diff   ~/.zshrc                 # reports divergence; no mutation
+wildflower diff                            # all meadows
+```
+
+Targeted operations:
+- Skip meadow-level `if` conditions and `meadow.gather()` / `meadow.sow()` callbacks (those are whole-meadow semantics; the user named the file explicitly).
+- Ignore meadow filters when an explicit path is given. Filters exist to restrict wholesale recursion; when a path is named on the CLI, it's gathered/sowed as-is.
+- Preserve symlinks (`expand: false` in both directions).
+
+## `wildflower path`
+
+A pure path-mapping primitive. Given a tracked path in either form, emits the path in the other store:
+
+```sh
+wildflower path ~/.zshrc
+# → /path/to/valley/meadows/~~/.zshrc
+
+wildflower path /path/to/valley/meadows/~~/.zshrc
+# → /Users/you/.zshrc
+```
+
+No I/O beyond reading `meadows.mjs`. Useful as a composable building block: `diff $(wildflower path ~/.zshrc) ~/.zshrc`, or `cp ~/.zshrc "$(wildflower path ~/.zshrc)"`.
+
+Exits non-zero if the path isn't covered by any meadow.
+
+## `wildflower diff`
+
+Reports divergence between live FS and the meadows mirror. Read-only; never mutates. Exit codes:
+- `0` — all checked paths identical
+- `1` — at least one divergence
+- `2` — at least one path not tracked, or other error
+
+Implementation delegates to `diff -rq` per pair.
+
 ## Todo:
 - Add ability for wildflower to run commands 
   - Note that the `sow` step current runs commands, but the `gather` step does not.

--- a/common.js
+++ b/common.js
@@ -3,6 +3,8 @@ import { spawn } from 'node:child_process'
 import fs from 'fs'
 import { cp, readdir, stat, statfs } from 'node:fs/promises';
 import { isNotJunk } from 'junk'
+import copy from 'recursive-copy'
+import maximatch from 'maximatch'
 
 const __dirname = import.meta.dirname;
 
@@ -163,14 +165,99 @@ export async function mapPath(targetPath) {
   return fixSourceControlPath(match.meadow.path) + rel
 }
 
+// Evaluate a meadow's filter against a path relative to the meadow root. The
+// filter is recursive-copy's form: an array of globs (`!` negates) or a
+// predicate. No filter means include everything.
+export function matchesFilter(filter, relPath) {
+  if (Array.isArray(filter)) return maximatch([relPath], filter).length > 0
+  if (typeof filter === 'function') return filter(relPath)
+  return true
+}
+
+// Copy a single tracked path (file or subtree) between the live filesystem and
+// its mirror. `direction` is 'gather' (live → mirror) or 'sow' (mirror → live);
+// `target` may be given in either live-FS or meadows-mirror form. Resolves the
+// owning meadow, honors that meadow's `if` condition and filter, then copies
+// only files under the target — leaving every other tracked file untouched, so
+// concurrent edits to other files don't bleed in. The per-meadow gather()/sow()
+// callbacks are intentionally skipped (whole-meadow semantics). Returns an exit
+// status (0 ok / 1 problem) rather than exiting, so callers can aggregate across
+// multiple targets.
+export async function copyPath(target, meadows, direction) {
+  const verb = direction === 'gather' ? 'gathered' : 'sown'
+  const match = findMeadowForPath(target, meadows)
+  if (!match) {
+    console.error(`Skipping '${target}': not in meadows.mjs (add it to track)`)
+    return 1
+  }
+  const { meadow, installed, absolute } = match
+  const index = meadows.indexOf(meadow)
+
+  const shouldRun = meadow.if ? await meadow.if() : true
+  if (!shouldRun) {
+    console.log(`Skipping '${absolute}' — ${meadowLabel(meadow, index)} condition didn't pass on this host.`)
+    return 0
+  }
+
+  // Path of the target relative to the meadow root (posix-style, as the meadow
+  // glob filters expect). Empty when the target IS the meadow root. The mirror
+  // preserves the live tree's layout, so this aligns for both directions.
+  const relTarget = absolute.slice(installed.length).replace(/^[\\/]/, '').split(path.sep).join('/')
+  const meadowFilter = meadow.filter
+
+  const options = {
+    dot: true,
+    overwrite: true,
+    expand: false,
+    filter(entry) {
+      const norm = String(entry).split(path.sep).join('/')
+      // Restrict the copy to the target (and the dirs needed to reach it).
+      if (relTarget !== '') {
+        const isTarget = norm === relTarget || norm.startsWith(relTarget + '/')
+        const isAncestorDir = relTarget.startsWith(norm + '/')
+        if (!isTarget && !isAncestorDir) return false
+        // Ancestor dirs only need traversal — skip the meadow filter for them.
+        if (isAncestorDir && !isTarget) return true
+      }
+      // Honor the meadow's own include/exclude filter (e.g. !*-tokens.json).
+      return matchesFilter(meadowFilter, norm)
+    },
+  }
+
+  // Copy from the meadow root (not the named subtree) so meadow-root-relative
+  // filter globs evaluate correctly; the filter narrows to the target.
+  const from = direction === 'gather' ? fixInstalledPath(meadow.path) : fixSourceControlPath(meadow.path)
+  const to = direction === 'gather' ? fixSourceControlPath(meadow.path) : fixInstalledPath(meadow.path)
+
+  try {
+    const operations = await (meadow.curable ? curableCopy : copy)(from, to, options)
+    const files = operations.filter((op) => op.stats?.isFile?.() ?? true)
+    if (files.length === 0) {
+      console.error(`Nothing ${verb} for '${absolute}' — excluded by the ${meadowLabel(meadow, index)} filter?`)
+      return 1
+    }
+    for (const op of files) {
+      console.log(`Copied '${op.src}' to '${op.dest}'`)
+    }
+    return 0
+  } catch (e) {
+    logNoSuchFile(e)
+    return 1
+  }
+}
+
 export async function curableCopy(
   fromPath,
   toPath,
   {
-    junk = false
+    junk = false,
+    // Mirrors recursive-copy's `filter`: an array of globs (with `!` negation)
+    // or a predicate, both keyed on the path relative to `fromPath`. Honored so
+    // curable meadows respect their include/exclude rules, like non-curable ones.
+    filter
   } = {}
 ) {
-  let files 
+  let files
   let statFromPath = await stat(fromPath)
   if (statFromPath.isDirectory()) {
     files = await readdir(fromPath, {
@@ -191,6 +278,9 @@ export async function curableCopy(
     if (file.isFile()) {
       if (junk === false && isNotJunk(file.name)) {
         let realFromPath = `${file.parentPath}/${file.name}`
+        // Path relative to fromPath (posix, no leading separator), as the filter expects.
+        let rel = realFromPath.slice(fromPath.length).replace(/^[\\/]/, '').split(path.sep).join('/')
+        if (!matchesFilter(filter, rel)) continue
         let realToPath = toPath + realFromPath.slice(fromPath.length)
         let operation = { src: realFromPath, dest: realToPath }
         try {

--- a/common.js
+++ b/common.js
@@ -96,6 +96,73 @@ export function fixSourceControlPath(filepath) {
   return path.join(getValleyDir(), "/meadows", filepath)
 }
 
+/**
+ * Given a path on disk (live FS or under meadows/), find the meadow
+ * declaration that covers it. Matches by longest prefix so a more specific
+ * meadow wins over a broader parent. Returns { meadow, installed, absolute }
+ * (installed = absolute live-FS root for the meadow; absolute = caller's
+ * path normalized to its live-FS form). Returns null if no meadow covers.
+ */
+export function findMeadowForPath(targetPath, meadows) {
+  const meadowsRoot = path.join(getValleyDir(), 'meadows')
+  let abs = targetPath
+  if (abs.startsWith('~')) abs = fixInstalledPath(abs)
+  abs = path.resolve(abs)
+
+  // If the path is under the meadows/ mirror, map it back to the live FS
+  // equivalent first so the lookup logic is single-pass.
+  if (abs === meadowsRoot || abs.startsWith(meadowsRoot + '/')) {
+    let mirrorRel = abs.slice(meadowsRoot.length).replace(/^\/+/, '')
+    // mirrorRel looks like '~~/.zshrc' — strip one `~` so we have `~/.zshrc`
+    if (mirrorRel.startsWith('~~')) mirrorRel = mirrorRel.slice(1)
+    abs = fixInstalledPath(mirrorRel)
+  }
+
+  let bestMeadow = null
+  let bestInstalled = null
+  let bestLen = -1
+  for (const meadow of meadows) {
+    if (!meadow.path) continue
+    const installed = path.resolve(fixInstalledPath(meadow.path))
+    if (abs === installed || abs.startsWith(installed + '/')) {
+      if (installed.length > bestLen) {
+        bestMeadow = meadow
+        bestInstalled = installed
+        bestLen = installed.length
+      }
+    }
+  }
+  if (!bestMeadow) return null
+  return { meadow: bestMeadow, installed: bestInstalled, absolute: abs }
+}
+
+/**
+ * Bidirectional path mapping. Given any tracked path (live FS form or
+ * meadows-mirror form), return the path in the other store.
+ * Throws if the input isn't covered by any meadow.
+ */
+export async function mapPath(targetPath) {
+  const { meadows } = await parseMeadows()
+  const match = findMeadowForPath(targetPath, meadows)
+  if (!match) {
+    const err = new Error(`path not in meadows.mjs; add it to track: ${targetPath}`)
+    err.code = 'ENOMEADOW'
+    throw err
+  }
+  const meadowsRoot = path.join(getValleyDir(), 'meadows')
+  let abs = targetPath
+  if (abs.startsWith('~')) abs = fixInstalledPath(abs)
+  abs = path.resolve(abs)
+
+  if (abs === meadowsRoot || abs.startsWith(meadowsRoot + '/')) {
+    // input is meadows-side → return live FS path
+    return match.absolute
+  }
+  // input is live FS → return meadow mirror path
+  const rel = match.absolute.slice(match.installed.length)
+  return fixSourceControlPath(match.meadow.path) + rel
+}
+
 export async function curableCopy(
   fromPath,
   toPath,

--- a/diff.js
+++ b/diff.js
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process'
+import * as fs from 'node:fs'
+import { parseMeadows, fixInstalledPath, fixSourceControlPath, findMeadowForPath, runDirectly } from './common.js'
+
+/**
+ * `wildflower diff [<path>...]` — report live FS vs meadows-mirror divergence
+ * for tracked paths. Read-only; never mutates. With no args, diffs every
+ * meadow; with args, diffs only the named paths.
+ *
+ * Implementation note: delegates to `diff -rq` (recursively report differing
+ * files, brief output). diff is universally available across the target hosts
+ * (mac/wsl/termux/stockholm). Exit code aggregates the diff exit codes:
+ *   0 = all paths identical
+ *   1 = at least one divergence (paths or content)
+ *   2 = at least one path not tracked or other error
+ */
+export async function diff(targets = null) {
+  const { meadows } = await parseMeadows()
+
+  let pairs = []
+  if (targets && targets.length > 0) {
+    let resolveErrors = 0
+    for (const target of targets) {
+      const match = findMeadowForPath(target, meadows)
+      if (!match) {
+        console.error(`Skipping '${target}': not in meadows.mjs`)
+        resolveErrors = 1
+        continue
+      }
+      const rel = match.absolute.slice(match.installed.length)
+      pairs.push({
+        live: match.absolute,
+        meadow: fixSourceControlPath(match.meadow.path) + rel,
+      })
+    }
+    if (resolveErrors && pairs.length === 0) {
+      process.exit(2)
+    }
+  } else {
+    for (const meadow of meadows) {
+      if (!meadow.path) continue
+      pairs.push({
+        live: fixInstalledPath(meadow.path),
+        meadow: fixSourceControlPath(meadow.path),
+      })
+    }
+  }
+
+  let aggregateExit = 0
+  for (const { live, meadow } of pairs) {
+    const liveExists = fs.existsSync(live)
+    const meadowExists = fs.existsSync(meadow)
+    if (!liveExists && !meadowExists) {
+      console.log(`Missing on both sides: ${live}`)
+      aggregateExit = Math.max(aggregateExit, 2)
+      continue
+    }
+    if (!liveExists) {
+      console.log(`Only in meadows: ${meadow}`)
+      aggregateExit = Math.max(aggregateExit, 1)
+      continue
+    }
+    if (!meadowExists) {
+      console.log(`Only in live FS: ${live}`)
+      aggregateExit = Math.max(aggregateExit, 1)
+      continue
+    }
+    const { code, out } = await runDiff(live, meadow)
+    if (out.trim()) console.log(out.trimEnd())
+    if (code !== 0) aggregateExit = Math.max(aggregateExit, code)
+  }
+
+  process.exit(aggregateExit)
+}
+
+function runDiff(live, meadow) {
+  return new Promise((resolve) => {
+    const child = spawn('diff', ['-rq', live, meadow], { stdio: ['ignore', 'pipe', 'pipe'] })
+    let out = ''
+    child.stdout.on('data', d => out += d)
+    child.stderr.on('data', d => out += d)
+    child.on('close', code => resolve({ code: code ?? 0, out }))
+  })
+}
+
+if (runDirectly()) await diff(process.argv.slice(2).length > 0 ? process.argv.slice(2) : null)

--- a/gather.js
+++ b/gather.js
@@ -2,8 +2,7 @@
 
 import copy from 'recursive-copy'
 import * as fs from 'node:fs'
-import path from 'node:path'
-import { parseMeadows, meadowLabel, curableCopy, findMeadowForPath } from './common.js'
+import { parseMeadows, meadowLabel, curableCopy, copyPath } from './common.js'
 import { fixInstalledPath, fixSourceControlPath, logNoSuchFile, buildCopyOptions, runDirectly } from './common.js'
 
 export async function gather(targets = null) {
@@ -11,33 +10,17 @@ export async function gather(targets = null) {
 
   fs.mkdirSync('./meadows', { recursive: true })
 
-  // Per-file (targeted) mode. Each target is a live FS path or a meadows
-  // mirror path; we resolve to the live FS form and copy just that path.
-  // Per-meadow `if` conditions and `meadow.gather()` callbacks are skipped
-  // because they're whole-meadow semantics; the user named the file
-  // explicitly and we honor that.
+  // Per-file (targeted) mode. Each target is a live FS path or a meadows mirror
+  // path; resolve to the owning meadow and copy just that path live FS → meadows,
+  // honoring the meadow's `if` condition and filter (so excluded paths like
+  // *-tokens.json are refused, not mirrored). The per-meadow gather() callback is
+  // skipped — that's whole-meadow semantics.
   if (targets && targets.length > 0) {
-    let exitCode = 0
+    let code = 0
     for (const target of targets) {
-      const match = findMeadowForPath(target, meadows)
-      if (!match) {
-        console.error(`Skipping '${target}': not in meadows.mjs (add it to track)`)
-        exitCode = 1
-        continue
-      }
-      const rel = match.absolute.slice(match.installed.length)
-      const src = match.absolute
-      const dst = fixSourceControlPath(match.meadow.path) + rel
-      try {
-        fs.mkdirSync(path.dirname(dst), { recursive: true })
-        await copy(src, dst, { dot: true, overwrite: true, expand: false })
-        console.log(`Gathered '${src}' to '${dst}'`)
-      } catch (e) {
-        logNoSuchFile(e)
-        exitCode = 1
-      }
+      code = Math.max(code, await copyPath(target, meadows, 'gather'))
     }
-    if (exitCode !== 0) process.exitCode = exitCode
+    if (code) process.exitCode = code
     return
   }
 

--- a/gather.js
+++ b/gather.js
@@ -2,11 +2,44 @@
 
 import copy from 'recursive-copy'
 import * as fs from 'node:fs'
-import { parseMeadows, meadowLabel, curableCopy } from './common.js'
+import path from 'node:path'
+import { parseMeadows, meadowLabel, curableCopy, findMeadowForPath } from './common.js'
 import { fixInstalledPath, fixSourceControlPath, logNoSuchFile, buildCopyOptions, runDirectly } from './common.js'
 
-export async function gather() {
+export async function gather(targets = null) {
   const { meadows } = await parseMeadows()
+
+  fs.mkdirSync('./meadows', { recursive: true })
+
+  // Per-file (targeted) mode. Each target is a live FS path or a meadows
+  // mirror path; we resolve to the live FS form and copy just that path.
+  // Per-meadow `if` conditions and `meadow.gather()` callbacks are skipped
+  // because they're whole-meadow semantics; the user named the file
+  // explicitly and we honor that.
+  if (targets && targets.length > 0) {
+    let exitCode = 0
+    for (const target of targets) {
+      const match = findMeadowForPath(target, meadows)
+      if (!match) {
+        console.error(`Skipping '${target}': not in meadows.mjs (add it to track)`)
+        exitCode = 1
+        continue
+      }
+      const rel = match.absolute.slice(match.installed.length)
+      const src = match.absolute
+      const dst = fixSourceControlPath(match.meadow.path) + rel
+      try {
+        fs.mkdirSync(path.dirname(dst), { recursive: true })
+        await copy(src, dst, { dot: true, overwrite: true, expand: false })
+        console.log(`Gathered '${src}' to '${dst}'`)
+      } catch (e) {
+        logNoSuchFile(e)
+        exitCode = 1
+      }
+    }
+    if (exitCode !== 0) process.exitCode = exitCode
+    return
+  }
 
   const copyOptions = {
     dot: true,
@@ -17,8 +50,6 @@ export async function gather() {
       return !(e.includes('node_modules'))
     }
   }
-
-  fs.mkdirSync('./meadows', { recursive: true })
 
   try {
     for (const [index, meadow] of Object.entries(meadows)) {
@@ -68,4 +99,4 @@ export async function gather() {
   // At some point, we should probably add a separate command to clean up files that have been previously committed, but aren't referenced by the meadows.mjs anymore. That would require some thinking so we don't remove files we're skipping on this system, but are referenced in meadows.mjs.
 }
 
-if (runDirectly()) await gather()
+if (runDirectly()) await gather(process.argv.slice(2).length > 0 ? process.argv.slice(2) : null)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wildflower",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "type": "module",
   "description": "an unopinionated tool for managing your dotflowers",
   "main": "wildflower.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wildflower",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "type": "module",
   "description": "an unopinionated tool for managing your dotflowers",
   "main": "wildflower.js",

--- a/path.js
+++ b/path.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+
+import { mapPath, runDirectly } from './common.js'
+
+/**
+ * `wildflower path <target>` — map a tracked path between its live FS form
+ * and its meadows-mirror form. Pure: no I/O beyond reading meadows.mjs.
+ *
+ * Direction is inferred from whether <target> is under the meadows/ tree
+ * or under the live FS (typically $HOME).
+ */
+export async function pathCmd(targets = []) {
+  if (targets.length === 0) {
+    console.error('Error: wildflower path requires at least one path argument')
+    process.exit(2)
+  }
+
+  let exitCode = 0
+  for (const target of targets) {
+    try {
+      const mapped = await mapPath(target)
+      console.log(mapped)
+    } catch (err) {
+      if (err.code === 'ENOMEADOW') {
+        console.error(err.message)
+        exitCode = 1
+      } else {
+        throw err
+      }
+    }
+  }
+  process.exit(exitCode)
+}
+
+if (runDirectly()) await pathCmd(process.argv.slice(2))

--- a/sow.js
+++ b/sow.js
@@ -1,13 +1,44 @@
 #!/usr/bin/env node
 
 import copy from 'recursive-copy'
-import { fixInstalledPath, fixSourceControlPath, logNoSuchFile, buildCopyOptions, parseMeadows, runDirectly, meadowLabel, curableCopy } from './common.js'
+import * as fs from 'node:fs'
+import path from 'node:path'
+import { fixInstalledPath, fixSourceControlPath, logNoSuchFile, buildCopyOptions, parseMeadows, runDirectly, meadowLabel, curableCopy, findMeadowForPath } from './common.js'
 
-export async function sow() {
+export async function sow(targets = null) {
   const { meadows } = await parseMeadows()
 
   if (!meadows) {
     throw new Error("No meadows found! Make sure you're defining it in your meadows.mjs. (e.g. `({ meadows: [...] })`)")
+  }
+
+  // Per-file (targeted) mode. Symmetric to gather's targeted mode: each
+  // target resolves to a meadow, and we copy just the mirror path back to
+  // its live FS location. Meadow `if` conditions and `meadow.sow()` callbacks
+  // are skipped because they're whole-meadow semantics.
+  if (targets && targets.length > 0) {
+    let exitCode = 0
+    for (const target of targets) {
+      const match = findMeadowForPath(target, meadows)
+      if (!match) {
+        console.error(`Skipping '${target}': not in meadows.mjs (add it to track)`)
+        exitCode = 1
+        continue
+      }
+      const rel = match.absolute.slice(match.installed.length)
+      const src = fixSourceControlPath(match.meadow.path) + rel
+      const dst = match.absolute
+      try {
+        fs.mkdirSync(path.dirname(dst), { recursive: true })
+        await copy(src, dst, { dot: true, overwrite: true, expand: false })
+        console.log(`Sowed '${src}' to '${dst}'`)
+      } catch (e) {
+        logNoSuchFile(e)
+        exitCode = 1
+      }
+    }
+    if (exitCode !== 0) process.exitCode = exitCode
+    return
   }
 
   const copyOptions = {
@@ -66,4 +97,4 @@ export async function sow() {
   }
 }
 
-if (runDirectly()) await sow()
+if (runDirectly()) await sow(process.argv.slice(2).length > 0 ? process.argv.slice(2) : null)

--- a/sow.js
+++ b/sow.js
@@ -11,9 +11,12 @@ export async function sow() {
   }
 
   const copyOptions = {
+    // expand: false preserves symlinks; tracking-as-symlinks (e.g. a script
+    // mirrored from a separate workspace) depends on this. Keep aligned with
+    // gather.js so the round-trip is type-preserving.
     dot: true,
     overwrite: true,
-    expand: true
+    expand: false
   }
 
   try {

--- a/sow.js
+++ b/sow.js
@@ -1,9 +1,7 @@
 #!/usr/bin/env node
 
 import copy from 'recursive-copy'
-import * as fs from 'node:fs'
-import path from 'node:path'
-import { fixInstalledPath, fixSourceControlPath, logNoSuchFile, buildCopyOptions, parseMeadows, runDirectly, meadowLabel, curableCopy, findMeadowForPath } from './common.js'
+import { fixInstalledPath, fixSourceControlPath, logNoSuchFile, buildCopyOptions, parseMeadows, runDirectly, meadowLabel, curableCopy, copyPath } from './common.js'
 
 export async function sow(targets = null) {
   const { meadows } = await parseMeadows()
@@ -12,32 +10,16 @@ export async function sow(targets = null) {
     throw new Error("No meadows found! Make sure you're defining it in your meadows.mjs. (e.g. `({ meadows: [...] })`)")
   }
 
-  // Per-file (targeted) mode. Symmetric to gather's targeted mode: each
-  // target resolves to a meadow, and we copy just the mirror path back to
-  // its live FS location. Meadow `if` conditions and `meadow.sow()` callbacks
-  // are skipped because they're whole-meadow semantics.
+  // Per-file (targeted) mode — symmetric to gather. Resolve each target to its
+  // owning meadow and copy just that path meadows → live FS, honoring the
+  // meadow's `if` condition and filter. The per-meadow sow() callback is skipped
+  // (whole-meadow semantics).
   if (targets && targets.length > 0) {
-    let exitCode = 0
+    let code = 0
     for (const target of targets) {
-      const match = findMeadowForPath(target, meadows)
-      if (!match) {
-        console.error(`Skipping '${target}': not in meadows.mjs (add it to track)`)
-        exitCode = 1
-        continue
-      }
-      const rel = match.absolute.slice(match.installed.length)
-      const src = fixSourceControlPath(match.meadow.path) + rel
-      const dst = match.absolute
-      try {
-        fs.mkdirSync(path.dirname(dst), { recursive: true })
-        await copy(src, dst, { dot: true, overwrite: true, expand: false })
-        console.log(`Sowed '${src}' to '${dst}'`)
-      } catch (e) {
-        logNoSuchFile(e)
-        exitCode = 1
-      }
+      code = Math.max(code, await copyPath(target, meadows, 'sow'))
     }
-    if (exitCode !== 0) process.exitCode = exitCode
+    if (code) process.exitCode = code
     return
   }
 

--- a/wildflower.js
+++ b/wildflower.js
@@ -3,22 +3,41 @@
 import { sow } from "./sow.js";
 import { gather } from "./gather.js";
 import { till } from "./till.js";
+import { pathCmd } from "./path.js";
+import { diff } from "./diff.js";
 import packageJson from './package.json' with { type: 'json' };
 
 let command = process.argv[2]
+let rest = process.argv.slice(3)
 
 if (command === 'sow') {
-  await sow()
+  await sow(rest.length > 0 ? rest : null)
 } else if (command === 'gather') {
-  await gather()
+  await gather(rest.length > 0 ? rest : null)
 } else if (command === 'till') {
   await till()
-} else if (command === 'version') {
+} else if (command === 'path') {
+  await pathCmd(rest)
+} else if (command === 'diff') {
+  await diff(rest.length > 0 ? rest : null)
+} else if (command === 'version' || command === '--version' || command === '-v') {
   console.log(packageJson.version)
+} else if (command === 'help' || command === '--help' || command === '-h') {
+  console.log(`wildflower ${packageJson.version}
+
+Commands:
+  gather [<path>...]   Copy live FS → meadows. With no args, wholesale.
+  sow    [<path>...]   Copy meadows → live FS. With no args, wholesale.
+  diff   [<path>...]   Report live-vs-meadows divergence. Read-only.
+  path   <path>        Map a tracked path between live FS and meadows form.
+  till                 Initialize a sample meadows.mjs.
+  version              Print version.
+`)
 } else {
   if (!command) {
-    console.error(`Error: Must provide a command: sow, gather, till`)
+    console.error(`Error: Must provide a command: gather, sow, diff, path, till. Use 'wildflower help' for details.`)
   } else {
     console.error(`Error: Unknown command '${command}'!`)
   }
+  process.exit(2)
 }


### PR DESCRIPTION
Reconciles the two parallel per-file-CLI implementations that both targeted `main`:

- **#22** (`per-file-gather`) — filter/`curable`-correct, but minimal (single path, no `path`/`diff`/`help`).
- **#19** (`fix/sow-preserve-symlinks`, carrying merged #20 `feat/per-file-cli`) — full CLI surface, but its per-file copy used a bare `copy(src, dst)` with **no filter and no `curable`**, so `wildflower gather <meadow>/x-tokens.json` would mirror a filter-excluded secret.

This branch is based on `feat/per-file-cli` (full surface) and ports in the correctness from `per-file-gather`.

## What it keeps (from feat)
Multi-path gather/sow, `path` + `diff` commands, `help`/`--version`/`-h`, bidirectional longest-match path resolution (`findMeadowForPath`/`mapPath`), symlink-preserving wholesale sow (`expand:false`), v3.1.0.

## What it fixes
- Per-file gather/sow route through a shared `copyPath(target, meadows, direction)` in `common.js` that **honors the meadow filter (excluded paths refused), `curable`, and `if`**. It copies from the meadow root with a target-narrowing filter so meadow-root-relative globs (e.g. `!scripts/lolm`) evaluate correctly, and returns an exit status so the multi-path loop aggregates.
- `curableCopy` now applies its `filter` arg (latent bug: wholesale curable meadows never honored their excludes either), via a shared `matchesFilter` helper.
- Per-file ops honor `if` (skip a named path whose meadow condition is false on this host); the per-meadow `gather()`/`sow()` callbacks remain skipped.

## Supersedes
Closes #22 and #19 (and the already-merged #20's content is incorporated). Note: merging will conflict with `main`'s `c14652e` (`gatherPath`) — resolve by taking the reconciled files.

## Verification
27/27 checks in an isolated-valley harness: multi-path, filter refusal, curable+filter, `if`-skip, bidirectional path arg, `path`/`diff` exit codes, wholesale + symlink round-trip, help/version/unknown-command.
