### PR TITLE
diff: honor meadow filters, per-command --help, and --verbose patch output

### DIFF
--- a/diff.js
+++ b/diff.js
@@ -6,22 +6,26 @@ import path from 'node:path'
 import { parseMeadows, fixInstalledPath, fixSourceControlPath, findMeadowForPath, matchesFilter, runDirectly } from './common.js'
 
 /**
- * `wildflower diff [<path>...]` — report live FS vs meadows-mirror divergence
- * for tracked paths. Read-only; never mutates. With no args, diffs every
- * meadow; with args, diffs only the named paths.
+ * `wildflower diff [<path>...] [--verbose]` — report live FS vs meadows-mirror
+ * divergence for tracked paths. Read-only; never mutates. With no args, diffs
+ * every meadow; with args, diffs only the named paths.
  *
  * Honors each meadow's filter: filter-excluded paths (e.g. *-tokens.json) are
  * never mirrored, so reporting them as divergent is just noise — they're
  * suppressed on both sides.
  *
- * Implementation note: delegates to `diff -rq` (recursively report differing
- * files, brief output). diff is universally available across the target hosts
- * (mac/wsl/termux/stockholm). Exit code aggregates:
+ * Brief by default (which files differ); `--verbose` additionally prints the
+ * unified patch for each differing file. One-sided files (present on only one
+ * side) stay brief even in verbose to avoid dumping whole files.
+ *
+ * Implementation note: delegates to `diff` (universally available across the
+ * target hosts: mac/wsl/termux/stockholm) — `-rq` to decide the filtered set,
+ * then `-u` per included differing file in verbose mode. Exit code aggregates:
  *   0 = all tracked paths identical
  *   1 = at least one divergence (paths or content)
  *   2 = at least one path not tracked or other error
  */
-export async function diff(targets = null) {
+export async function diff(targets = null, { verbose = false } = {}) {
   const { meadows } = await parseMeadows()
 
   let pairs = []
@@ -88,15 +92,23 @@ export async function diff(targets = null) {
       aggregateExit = Math.max(aggregateExit, 1)
       continue
     }
-    const { out } = await runDiff(live, meadow)
+    const { out } = await runDiff(['-rq', live, meadow])
     // Drop lines about filter-excluded paths; report only tracked divergence.
-    const kept = out.split('\n').filter((line) => {
-      if (!line.trim()) return false
-      const p = pathFromDiffLine(line)
-      return p === null || included(p)
-    })
-    if (kept.length) {
-      console.log(kept.join('\n'))
+    const blocks = []
+    for (const line of out.split('\n')) {
+      if (!line.trim()) continue
+      const info = parseDiffLine(line)
+      if (info && info.path !== null && !included(info.path)) continue
+      if (verbose && info && info.a && info.b) {
+        // Expand "Files A and B differ" into its unified patch.
+        const { out: patch } = await runDiff(['-u', info.a, info.b])
+        blocks.push(patch.trimEnd() || line)
+      } else {
+        blocks.push(line)
+      }
+    }
+    if (blocks.length) {
+      console.log(blocks.join('\n'))
       aggregateExit = Math.max(aggregateExit, 1)
     }
   }
@@ -111,19 +123,21 @@ function relUnder(p, root) {
   return null
 }
 
-// Extract the filesystem path a `diff -rq` line refers to, or null for lines
-// whose shape we don't recognize (kept as-is so real errors stay visible).
-function pathFromDiffLine(line) {
-  let m = line.match(/^Only in (.+?): (.+)$/)
-  if (m) return path.join(m[1], m[2])
-  m = line.match(/^Files (.+?) and (.+?) differ$/)
-  if (m) return m[1]
+// Parse a `diff -rq` line into { path, a, b }: `path` is the filesystem path the
+// line refers to (for filtering); `a`/`b` are the two file paths when the line
+// is "Files A and B differ" (so verbose mode can re-diff them), else null.
+// Unrecognized lines return null and are kept as-is (real errors stay visible).
+function parseDiffLine(line) {
+  let m = line.match(/^Files (.+?) and (.+?) differ$/)
+  if (m) return { path: m[1], a: m[1], b: m[2] }
+  m = line.match(/^Only in (.+?): (.+)$/)
+  if (m) return { path: path.join(m[1], m[2]), a: null, b: null }
   return null
 }
 
-function runDiff(live, meadow) {
+function runDiff(args) {
   return new Promise((resolve) => {
-    const child = spawn('diff', ['-rq', live, meadow], { stdio: ['ignore', 'pipe', 'pipe'] })
+    const child = spawn('diff', args, { stdio: ['ignore', 'pipe', 'pipe'] })
     let out = ''
     child.stdout.on('data', d => out += d)
     child.stderr.on('data', d => out += d)
@@ -131,4 +145,9 @@ function runDiff(live, meadow) {
   })
 }
 
-if (runDirectly()) await diff(process.argv.slice(2).length > 0 ? process.argv.slice(2) : null)
+if (runDirectly()) {
+  const args = process.argv.slice(2)
+  const verbose = args.includes('--verbose')
+  const paths = args.filter((a) => a !== '--verbose')
+  await diff(paths.length > 0 ? paths : null, { verbose })
+}

--- a/diff.js
+++ b/diff.js
@@ -2,17 +2,22 @@
 
 import { spawn } from 'node:child_process'
 import * as fs from 'node:fs'
-import { parseMeadows, fixInstalledPath, fixSourceControlPath, findMeadowForPath, runDirectly } from './common.js'
+import path from 'node:path'
+import { parseMeadows, fixInstalledPath, fixSourceControlPath, findMeadowForPath, matchesFilter, runDirectly } from './common.js'
 
 /**
  * `wildflower diff [<path>...]` — report live FS vs meadows-mirror divergence
  * for tracked paths. Read-only; never mutates. With no args, diffs every
  * meadow; with args, diffs only the named paths.
  *
+ * Honors each meadow's filter: filter-excluded paths (e.g. *-tokens.json) are
+ * never mirrored, so reporting them as divergent is just noise — they're
+ * suppressed on both sides.
+ *
  * Implementation note: delegates to `diff -rq` (recursively report differing
  * files, brief output). diff is universally available across the target hosts
- * (mac/wsl/termux/stockholm). Exit code aggregates the diff exit codes:
- *   0 = all paths identical
+ * (mac/wsl/termux/stockholm). Exit code aggregates:
+ *   0 = all tracked paths identical
  *   1 = at least one divergence (paths or content)
  *   2 = at least one path not tracked or other error
  */
@@ -33,6 +38,9 @@ export async function diff(targets = null) {
       pairs.push({
         live: match.absolute,
         meadow: fixSourceControlPath(match.meadow.path) + rel,
+        root: match.installed,
+        mirrorRoot: fixSourceControlPath(match.meadow.path),
+        filter: match.meadow.filter,
       })
     }
     if (resolveErrors && pairs.length === 0) {
@@ -44,12 +52,23 @@ export async function diff(targets = null) {
       pairs.push({
         live: fixInstalledPath(meadow.path),
         meadow: fixSourceControlPath(meadow.path),
+        root: path.resolve(fixInstalledPath(meadow.path)),
+        mirrorRoot: fixSourceControlPath(meadow.path),
+        filter: meadow.filter,
       })
     }
   }
 
   let aggregateExit = 0
-  for (const { live, meadow } of pairs) {
+  for (const { live, meadow, root, mirrorRoot, filter } of pairs) {
+    // Whether a path (under either root) is included by the meadow's filter.
+    const included = (p) => {
+      let rel = relUnder(p, root)
+      if (rel === null) rel = relUnder(p, mirrorRoot)
+      if (rel === null) return true
+      return matchesFilter(filter, rel)
+    }
+
     const liveExists = fs.existsSync(live)
     const meadowExists = fs.existsSync(meadow)
     if (!liveExists && !meadowExists) {
@@ -58,21 +77,48 @@ export async function diff(targets = null) {
       continue
     }
     if (!liveExists) {
+      if (!included(meadow)) continue
       console.log(`Only in meadows: ${meadow}`)
       aggregateExit = Math.max(aggregateExit, 1)
       continue
     }
     if (!meadowExists) {
+      if (!included(live)) continue
       console.log(`Only in live FS: ${live}`)
       aggregateExit = Math.max(aggregateExit, 1)
       continue
     }
-    const { code, out } = await runDiff(live, meadow)
-    if (out.trim()) console.log(out.trimEnd())
-    if (code !== 0) aggregateExit = Math.max(aggregateExit, code)
+    const { out } = await runDiff(live, meadow)
+    // Drop lines about filter-excluded paths; report only tracked divergence.
+    const kept = out.split('\n').filter((line) => {
+      if (!line.trim()) return false
+      const p = pathFromDiffLine(line)
+      return p === null || included(p)
+    })
+    if (kept.length) {
+      console.log(kept.join('\n'))
+      aggregateExit = Math.max(aggregateExit, 1)
+    }
   }
 
   process.exit(aggregateExit)
+}
+
+// Path of `p` relative to `root` (posix), or null if not under root.
+function relUnder(p, root) {
+  if (p === root) return ''
+  if (p.startsWith(root + path.sep)) return p.slice(root.length + 1).split(path.sep).join('/')
+  return null
+}
+
+// Extract the filesystem path a `diff -rq` line refers to, or null for lines
+// whose shape we don't recognize (kept as-is so real errors stay visible).
+function pathFromDiffLine(line) {
+  let m = line.match(/^Only in (.+?): (.+)$/)
+  if (m) return path.join(m[1], m[2])
+  m = line.match(/^Files (.+?) and (.+?) differ$/)
+  if (m) return m[1]
+  return null
 }
 
 function runDiff(live, meadow) {

--- a/wildflower.js
+++ b/wildflower.js
@@ -7,10 +7,61 @@ import { pathCmd } from "./path.js";
 import { diff } from "./diff.js";
 import packageJson from './package.json' with { type: 'json' };
 
+const VERSION = packageJson.version
+
+const TOP_HELP = `wildflower ${VERSION}
+
+Commands:
+  gather [<path>...]   Copy live FS → meadows. With no args, wholesale.
+  sow    [<path>...]   Copy meadows → live FS. With no args, wholesale.
+  diff   [<path>...]   Report live-vs-meadows divergence. Read-only.
+  path   <path>...     Map a tracked path between live FS and meadows form.
+  till                 Initialize a sample meadows.mjs.
+  version              Print version.
+
+Run 'wildflower <command> --help' for details on a command.`
+
+// Per-command help, shown for `wildflower <command> --help` / `-h`.
+const COMMAND_HELP = {
+  gather: `wildflower gather [<path>...]
+
+Copy files from the live filesystem into the meadows mirror. With no <path>,
+gathers every meadow wholesale. With one or more <path> (live-FS or mirror
+form), gathers only those, honoring each meadow's \`if\` condition and filter
+(excluded paths like *-tokens.json are refused, not mirrored).`,
+  sow: `wildflower sow [<path>...]
+
+Copy files from the meadows mirror back to the live filesystem. With no <path>,
+sows every meadow wholesale. With one or more <path>, sows only those, honoring
+each meadow's \`if\` condition and filter.`,
+  diff: `wildflower diff [<path>...]
+
+Report divergence between the live filesystem and the meadows mirror. Read-only;
+never mutates. Honors each meadow's filter, so excluded paths (e.g.
+*-tokens.json) are not reported. With no <path>, diffs every meadow.
+
+Exit codes: 0 = identical, 1 = differ, 2 = path not tracked / error.`,
+  path: `wildflower path <path>...
+
+Map tracked path(s) between live-FS form and meadows-mirror form. Pure: reads
+meadows.mjs only, no copying. Direction is inferred from each input.`,
+  till: `wildflower till
+
+Initialize a sample meadows.mjs and meadows/ directory in the current valley.`,
+  version: `wildflower version
+
+Print the installed wildflower version.`,
+}
+
 let command = process.argv[2]
 let rest = process.argv.slice(3)
 
-if (command === 'sow') {
+const wantsHelp = (args) => args.includes('--help') || args.includes('-h')
+
+if (command && COMMAND_HELP[command] && wantsHelp(rest)) {
+  // `wildflower <command> --help`
+  console.log(COMMAND_HELP[command])
+} else if (command === 'sow') {
   await sow(rest.length > 0 ? rest : null)
 } else if (command === 'gather') {
   await gather(rest.length > 0 ? rest : null)
@@ -21,18 +72,9 @@ if (command === 'sow') {
 } else if (command === 'diff') {
   await diff(rest.length > 0 ? rest : null)
 } else if (command === 'version' || command === '--version' || command === '-v') {
-  console.log(packageJson.version)
+  console.log(VERSION)
 } else if (command === 'help' || command === '--help' || command === '-h') {
-  console.log(`wildflower ${packageJson.version}
-
-Commands:
-  gather [<path>...]   Copy live FS → meadows. With no args, wholesale.
-  sow    [<path>...]   Copy meadows → live FS. With no args, wholesale.
-  diff   [<path>...]   Report live-vs-meadows divergence. Read-only.
-  path   <path>        Map a tracked path between live FS and meadows form.
-  till                 Initialize a sample meadows.mjs.
-  version              Print version.
-`)
+  console.log(TOP_HELP)
 } else {
   if (!command) {
     console.error(`Error: Must provide a command: gather, sow, diff, path, till. Use 'wildflower help' for details.`)

--- a/wildflower.js
+++ b/wildflower.js
@@ -34,11 +34,14 @@ form), gathers only those, honoring each meadow's \`if\` condition and filter
 Copy files from the meadows mirror back to the live filesystem. With no <path>,
 sows every meadow wholesale. With one or more <path>, sows only those, honoring
 each meadow's \`if\` condition and filter.`,
-  diff: `wildflower diff [<path>...]
+  diff: `wildflower diff [<path>...] [--verbose]
 
 Report divergence between the live filesystem and the meadows mirror. Read-only;
 never mutates. Honors each meadow's filter, so excluded paths (e.g.
 *-tokens.json) are not reported. With no <path>, diffs every meadow.
+
+  --verbose   Print the unified patch for each differing file (default: just
+              report which files differ).
 
 Exit codes: 0 = identical, 1 = differ, 2 = path not tracked / error.`,
   path: `wildflower path <path>...
@@ -70,7 +73,9 @@ if (command && COMMAND_HELP[command] && wantsHelp(rest)) {
 } else if (command === 'path') {
   await pathCmd(rest)
 } else if (command === 'diff') {
-  await diff(rest.length > 0 ? rest : null)
+  const verbose = rest.includes('--verbose')
+  const paths = rest.filter((a) => a !== '--verbose')
+  await diff(paths.length > 0 ? paths : null, { verbose })
 } else if (command === 'version' || command === '--version' || command === '-v') {
   console.log(VERSION)
 } else if (command === 'help' || command === '--help' || command === '-h') {


### PR DESCRIPTION
Follow-ups to #23 (merged), addressing rough edges in `wildflower diff`.

## `diff` honors meadow filters
Previously `diff` reported filter-excluded paths (e.g. `*-tokens.json`) as "Only in live FS" — they're never mirrored, so it was pure noise. It now maps each `diff -rq` output line back to its meadow-relative path and drops anything the meadow's filter excludes (both sides). A pair whose only divergence is excluded files is treated as identical (exit 0); real tracked divergence still reports and exits 1.

## Per-command `--help`
`wildflower <command> --help` / `-h` now prints command-specific usage for all of `gather`/`sow`/`diff`/`path`/`till`/`version` (previously `--help` was parsed as a path argument → exit 2). Top-level `help` unchanged.

## `diff --verbose`
Brief mode (`diff -rq`) only reports *which* files differ. `--verbose` re-diffs each included differing file with `diff -u` and prints the unified patch. Two-pass design so filter-honoring is unchanged; one-sided files stay brief to avoid dumping whole files. Flag is order-independent and documented in `diff --help`.

## Verification
Isolated-valley harness: 27/27. Plus targeted checks — excluded-only divergence is silent (exit 0), real divergence reports (exit 1), `--verbose` shows the patch with excluded files suppressed, all subcommands answer `--help` (exit 0).