### PR TITLE
Add `wildflower status`, and key the watermark to the main checkout

### DIFF
--- a/common.js
+++ b/common.js
@@ -57,24 +57,42 @@ export function getValleyDir() {
 }
 
 /**
- * Records the commit the live filesystem was synced to, written to the valley
- * root after a wholesale sow. This watermark is the merge base for a later
- * 3-way merge when the live filesystem and the mirror diverge. Self-contained
- * try/catch: a non-git valley or git failure degrades gracefully and never
- * aborts a sow.
+ * Directory that owns the sync watermark. All worktrees of a valley share one
+ * home directory, so they must share one watermark: `--git-common-dir` points
+ * at the main checkout's `.git` from anywhere, and its parent is the main
+ * checkout. For a plain (non-worktree) checkout this resolves to the valley
+ * itself, so hosts see no change.
+ */
+export function getWatermarkDir() {
+  const valley = getValleyDir()
+  try {
+    const common = execSync('git rev-parse --git-common-dir', { cwd: valley, stdio: ['ignore', 'pipe', 'ignore'] })
+      .toString().trim()
+    return path.dirname(path.resolve(valley, common))
+  } catch {
+    return valley // not a git repo; behave as before
+  }
+}
+
+/**
+ * Records the commit the live filesystem was synced to, written to the main
+ * checkout's root after a wholesale sow. This watermark is the merge base for a
+ * later 3-way merge when the live filesystem and the mirror diverge.
+ * Self-contained try/catch: a non-git valley or git failure degrades gracefully
+ * and never aborts a sow.
  */
 export function writeSyncMetadata() {
-  const valley = getValleyDir()
+  const dir = getWatermarkDir()
   let commit
   try {
-    commit = execSync('git rev-parse HEAD', { cwd: valley, stdio: ['ignore', 'pipe', 'ignore'] })
+    commit = execSync('git rev-parse HEAD', { cwd: dir, stdio: ['ignore', 'pipe', 'ignore'] })
       .toString().trim()
   } catch {
     console.error('Warning: valley is not a git repo or HEAD unreadable; skipping sync metadata.')
     return
   }
   const meta = { commit, sownAt: new Date().toISOString(), wildflowerVersion: packageJson.version }
-  fs.writeFileSync(path.join(valley, '.wildflower-state.json'), JSON.stringify(meta, null, 2) + '\n')
+  fs.writeFileSync(path.join(dir, '.wildflower-state.json'), JSON.stringify(meta, null, 2) + '\n')
 }
 
 export function buildCopyOptions(baseOptions, meadow) {
@@ -194,6 +212,15 @@ export function matchesFilter(filter, relPath) {
   if (Array.isArray(filter)) return maximatch([relPath], filter).length > 0
   if (typeof filter === 'function') return filter(relPath)
   return true
+}
+
+// Path of `p` relative to `root` (posix), or null if not under root. Lives here
+// rather than in diff.js so status.js can reach it without importing diff.js,
+// whose module-level runDirectly() block would run a diff on the way past.
+export function relUnder(p, root) {
+  if (p === root) return ''
+  if (p.startsWith(root + path.sep)) return p.slice(root.length + 1).split(path.sep).join('/')
+  return null
 }
 
 // Copy a single tracked path (file or subtree) between the live filesystem and

--- a/diff.js
+++ b/diff.js
@@ -3,7 +3,10 @@
 import { spawn } from 'node:child_process'
 import * as fs from 'node:fs'
 import path from 'node:path'
-import { parseMeadows, fixInstalledPath, fixSourceControlPath, findMeadowForPath, matchesFilter, runDirectly } from './common.js'
+import { parseMeadows, fixInstalledPath, fixSourceControlPath, findMeadowForPath, matchesFilter, relUnder, runDirectly } from './common.js'
+
+// Re-exported for callers (and tests) that have always reached for it here.
+export { relUnder }
 
 /**
  * `wildflower diff [<path>...] [--verbose]` — report live FS vs meadows-mirror
@@ -114,13 +117,6 @@ export async function diff(targets = null, { verbose = false } = {}) {
   }
 
   process.exit(aggregateExit)
-}
-
-// Path of `p` relative to `root` (posix), or null if not under root.
-export function relUnder(p, root) {
-  if (p === root) return ''
-  if (p.startsWith(root + path.sep)) return p.slice(root.length + 1).split(path.sep).join('/')
-  return null
 }
 
 // Parse a `diff -rq` line into { path, a, b }: `path` is the filesystem path the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wildflower",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "type": "module",
   "description": "an unopinionated tool for managing your dotflowers",
   "main": "wildflower.js",
@@ -17,6 +17,7 @@
     "gather.js",
     "path.js",
     "sow.js",
+    "status.js",
     "till.js",
     "wildflower.js",
     "install.sh",

--- a/sow.js
+++ b/sow.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import copy from 'recursive-copy'
-import { fixInstalledPath, fixSourceControlPath, logNoSuchFile, buildCopyOptions, parseMeadows, runDirectly, meadowLabel, curableCopy, copyPath, writeSyncMetadata } from './common.js'
+import { fixInstalledPath, fixSourceControlPath, logNoSuchFile, buildCopyOptions, parseMeadows, runDirectly, meadowLabel, curableCopy, copyPath, writeSyncMetadata, getValleyDir, getWatermarkDir } from './common.js'
 
 export async function sow(targets = null) {
   const { meadows } = await parseMeadows()
@@ -21,6 +21,20 @@ export async function sow(targets = null) {
     }
     if (code) process.exitCode = code
     return
+  }
+
+  // Wholesale sow is only meaningful from the main checkout. From a linked
+  // worktree it would deliver a session branch's mirror to the shared home
+  // directory and stamp the watermark with a session-branch commit that
+  // landing is about to rewrite into new SHAs and then delete, leaving the
+  // watermark naming a commit no branch reaches. Refuse before copying
+  // anything; per-file sow is unaffected (it returns above, and never stamps).
+  const valley = getValleyDir()
+  const mainCheckout = getWatermarkDir()
+  if (mainCheckout !== valley) {
+    console.error(`Error: refusing a wholesale sow from the linked worktree ${valley}.`)
+    console.error(`Run it from the main checkout (${mainCheckout}), or sow individual paths: wildflower sow <path>`)
+    process.exit(2)
   }
 
   const copyOptions = {
@@ -74,9 +88,8 @@ export async function sow(targets = null) {
     }
 
     // Records HEAD at sow time as the watermark; a valid 3-way merge base only
-    // when the valley working tree was clean at sow. Only wholesale sow should
-    // advance it — a future per-file sow must NOT write it. Sow is wholesale-only
-    // today, so this single call site is correct.
+    // when the valley working tree was clean at sow. Only wholesale sow advances
+    // it - per-file sow returns above, before this point.
     writeSyncMetadata()
 
     console.log('Done sowing.')

--- a/status.js
+++ b/status.js
@@ -1,0 +1,247 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process'
+import crypto from 'node:crypto'
+import * as fs from 'node:fs'
+import path from 'node:path'
+import {
+  parseMeadows,
+  fixInstalledPath,
+  fixSourceControlPath,
+  findMeadowForPath,
+  matchesFilter,
+  relUnder,
+  runDirectly,
+  getValleyDir,
+  getWatermarkDir,
+} from './common.js'
+
+/**
+ * `wildflower status [<path>...] [--porcelain|--json]` - classify every tracked
+ * path by which side of the mirror has moved. Read-only; never mutates.
+ *
+ * `diff` answers "do these two files differ"; status answers the question that
+ * actually decides what to do about it, by bringing in the sync watermark
+ * (.wildflower-state.json, the commit the live FS was last sown to) as a third
+ * input and treating it as a merge base:
+ *
+ *   missing   the mirror tracks it, the live filesystem doesn't have it
+ *   synced    live content equals the mirror
+ *   behind    live differs from the mirror but equals the watermark's blob for
+ *             that path, so the mirror moved on and live is just un-sown
+ *   ahead     live differs from both: someone edited it live since the sow
+ *   unknown   no watermark, or the watermark commit is unreachable
+ *
+ * Files are enumerated from the mirror, so a live-only file (never gathered) is
+ * out of scope here, and `sow` won't touch it either. Use `diff` to see those.
+ *
+ * Exit codes: 0 = nothing ahead, 1 = at least one path ahead, 2 = a named path
+ * isn't tracked, or the valley isn't a git repo.
+ */
+export async function status(targets = null, { porcelain = false, json = false } = {}) {
+  const { meadows } = await parseMeadows()
+  const valley = getValleyDir()
+  const watermarkDir = getWatermarkDir()
+
+  if (!isGitRepo(watermarkDir)) {
+    console.error(`Error: valley is not a git repo, so there is no watermark to compare against: ${valley}`)
+    process.exitCode = 2
+    return
+  }
+
+  // Meadow/target resolution mirrors diff.js: a target names a path inside some
+  // meadow, and with no targets every meadow with a path is in scope.
+  let untracked = false
+  const pairs = []
+  if (targets && targets.length > 0) {
+    for (const target of targets) {
+      const match = findMeadowForPath(target, meadows)
+      if (!match) {
+        console.error(`Skipping '${target}': not in meadows.mjs`)
+        untracked = true
+        continue
+      }
+      const rel = match.absolute.slice(match.installed.length)
+      pairs.push({
+        meadow: match.meadow,
+        mirror: fixSourceControlPath(match.meadow.path) + rel,
+        root: match.installed,
+        mirrorRoot: fixSourceControlPath(match.meadow.path),
+      })
+    }
+  } else {
+    for (const meadow of meadows) {
+      if (!meadow.path) continue
+      pairs.push({
+        meadow,
+        mirror: fixSourceControlPath(meadow.path),
+        root: path.resolve(fixInstalledPath(meadow.path)),
+        mirrorRoot: fixSourceControlPath(meadow.path),
+      })
+    }
+  }
+
+  // Keyed by live path so overlapping meadows or overlapping targets don't
+  // report the same file twice.
+  const tracked = new Map()
+  for (const pair of pairs) {
+    const shouldRun = pair.meadow.if ? await pair.meadow.if() : true
+    if (!shouldRun) continue
+    for (const mirrorFile of walk(pair.mirror)) {
+      const rel = relUnder(mirrorFile, pair.mirrorRoot)
+      if (rel === null) continue
+      if (!matchesFilter(pair.meadow.filter, rel)) continue
+      const live = rel === '' ? pair.root : path.join(pair.root, rel)
+      tracked.set(live, mirrorFile)
+    }
+  }
+
+  const watermark = readWatermark(watermarkDir)
+  // Loaded on first need: a fully synced valley never has to read the tree.
+  let baseTree
+
+  function classify(live, mirror) {
+    const liveId = blobIdOfPath(live)
+    if (liveId === null) return 'missing'
+    if (liveId === blobIdOfPath(mirror)) return 'synced'
+    // Diverged from the mirror. Only the watermark says which side moved.
+    if (!watermark) return 'unknown'
+    if (baseTree === undefined) baseTree = readBaseTree(watermarkDir, watermark)
+    if (baseTree === null) return 'unknown'
+    const key = relUnder(mirror, valley)
+    return key !== null && baseTree.get(key) === liveId ? 'behind' : 'ahead'
+  }
+
+  const results = []
+  for (const [live, mirror] of tracked) {
+    results.push({ state: classify(live, mirror), live, mirror })
+  }
+
+  const rank = { ahead: 0, unknown: 1, behind: 2, missing: 3, synced: 4 }
+  results.sort((a, b) => (rank[a.state] - rank[b.state]) || a.live.localeCompare(b.live))
+
+  const counts = { ahead: 0, unknown: 0, behind: 0, missing: 0, synced: 0 }
+  for (const r of results) counts[r.state]++
+
+  if (json) {
+    console.log(JSON.stringify({ watermark, counts, files: results }, null, 2))
+  } else if (porcelain) {
+    // Like `git status --porcelain`: only what isn't clean.
+    for (const r of results) {
+      if (r.state !== 'synced') console.log(`${r.state}\t${r.live}`)
+    }
+  } else {
+    for (const r of results) {
+      if (r.state !== 'synced') console.log(`${r.state.padEnd(7)} ${r.live}`)
+    }
+    console.log(
+      `${results.length} tracked, ${counts.synced} synced, ${counts.ahead} ahead, ` +
+      `${counts.behind} behind, ${counts.missing} missing, ${counts.unknown} unknown`
+    )
+    if (counts.unknown > 0) {
+      console.error(
+        watermark
+          ? `Warning: watermark commit ${watermark} is unreachable (orphaned by a rebase?). Run a wholesale sow to re-establish it, or reconstruct it with dotfiles-find-ancestor.sh.`
+          : 'Warning: no watermark recorded in .wildflower-state.json, so behind and ahead cannot be told apart. Run a wholesale sow to establish one.'
+      )
+    }
+  }
+
+  // exitCode rather than exit(): stdout is async when it's a pipe, and
+  // process.exit() drops whatever is still buffered. --json on a real valley
+  // is large enough to be truncated mid-object by that.
+  process.exitCode = untracked ? 2 : counts.ahead > 0 ? 1 : 0
+}
+
+function isGitRepo(dir) {
+  try {
+    execFileSync('git', ['rev-parse', '--git-dir'], { cwd: dir, stdio: ['ignore', 'ignore', 'ignore'] })
+    return true
+  } catch {
+    return false
+  }
+}
+
+// The commit the live filesystem was last sown to, or null when there's no
+// usable record (absent file, unreadable, malformed).
+function readWatermark(dir) {
+  try {
+    const commit = JSON.parse(fs.readFileSync(path.join(dir, '.wildflower-state.json'), 'utf8')).commit
+    return typeof commit === 'string' && commit ? commit : null
+  } catch {
+    return null
+  }
+}
+
+// Repo-relative path to blob id, for every file in the watermark commit's tree.
+// One `git ls-tree` rather than a `git rev-parse <commit>:<path>` per file,
+// which matters at a few thousand tracked files. Null when the commit is
+// unreachable, which is the caller's cue to report `unknown` rather than guess.
+function readBaseTree(dir, commit) {
+  let out
+  try {
+    out = execFileSync('git', ['ls-tree', '-r', '-z', commit], {
+      cwd: dir,
+      stdio: ['ignore', 'pipe', 'ignore'],
+      maxBuffer: 256 * 1024 * 1024,
+    }).toString()
+  } catch {
+    return null
+  }
+  // Each -z record is `<mode> <type> <object>\t<path>` with the path unquoted.
+  const tree = new Map()
+  for (const record of out.split('\0')) {
+    const tab = record.indexOf('\t')
+    if (tab < 0) continue
+    const meta = record.slice(0, tab).split(' ')
+    if (meta.length < 3) continue
+    tree.set(record.slice(tab + 1), meta[2])
+  }
+  return tree
+}
+
+// Every file under `root`, which may itself be a single file.
+function walk(root) {
+  let st
+  try {
+    st = fs.lstatSync(root)
+  } catch {
+    return []
+  }
+  if (!st.isDirectory()) return [root]
+  const files = []
+  for (const entry of fs.readdirSync(root, { withFileTypes: true, recursive: true })) {
+    if (entry.isDirectory()) continue
+    files.push(path.join(entry.parentPath ?? entry.path, entry.name))
+  }
+  return files
+}
+
+// Git's blob id for a buffer: sha1("blob <len>\0" + content). Computed here
+// rather than shelling out to `git hash-object`, because one spawn per file
+// would dominate the run in a valley with thousands of tracked files.
+function blobId(buf) {
+  return crypto.createHash('sha1').update(`blob ${buf.length}\0`).update(buf).digest('hex')
+}
+
+// Blob id for a path on disk, or null when there's no file there. A symlink
+// hashes its target string, which is what git stores for it, so a tracked
+// symlink compares correctly against both the mirror and a committed blob.
+function blobIdOfPath(p) {
+  try {
+    const st = fs.lstatSync(p)
+    if (st.isSymbolicLink()) return blobId(Buffer.from(fs.readlinkSync(p)))
+    if (!st.isFile()) return null
+    return blobId(fs.readFileSync(p))
+  } catch {
+    return null
+  }
+}
+
+if (runDirectly()) {
+  const args = process.argv.slice(2)
+  const porcelain = args.includes('--porcelain')
+  const json = args.includes('--json')
+  const paths = args.filter((a) => a !== '--porcelain' && a !== '--json')
+  await status(paths.length > 0 ? paths : null, { porcelain, json })
+}

--- a/test/status.test.js
+++ b/test/status.test.js
@@ -1,0 +1,182 @@
+import { describe, it, after } from 'node:test'
+import assert from 'node:assert/strict'
+import os from 'node:os'
+import path from 'node:path'
+import fs from 'node:fs'
+import { execSync, spawnSync } from 'node:child_process'
+
+// status() ends in process.exit() and getValleyDir() caches its answer for the
+// life of the module, so each case runs the real CLI in a child process with
+// its own VALLEY_PATH and HOME. That also exercises the exit codes, which are
+// the part dotfiles-update.sh depends on.
+const CLI = path.join(import.meta.dirname, '..', 'wildflower.js')
+
+const roots = []
+after(() => {
+  for (const root of roots) fs.rmSync(root, { recursive: true, force: true })
+})
+
+// A valley tracking a single `~/dots` meadow, with the four files below sown to
+// live and committed to the mirror, and the watermark pointing at that commit.
+// Callers then move one side or the other to produce the state under test.
+function setup({ git = true } = {}) {
+  const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'wf-status-')))
+  roots.push(root)
+  const home = path.join(root, 'home')
+  const valley = path.join(root, 'valley')
+  const mirror = path.join(valley, 'meadows', '~~', 'dots')
+  const live = path.join(home, 'dots')
+  fs.mkdirSync(mirror, { recursive: true })
+  fs.mkdirSync(live, { recursive: true })
+  fs.writeFileSync(path.join(valley, 'meadows.mjs'), 'export const meadows = [{ path: "~/dots" }]\n')
+
+  for (const name of ['synced.txt', 'behind.txt', 'ahead.txt', 'gone.txt']) {
+    fs.writeFileSync(path.join(mirror, name), 'v1\n')
+    fs.writeFileSync(path.join(live, name), 'v1\n')
+  }
+
+  let commit = null
+  if (git) {
+    const run = (cmd) => execSync(cmd, { cwd: valley, stdio: 'ignore' })
+    run('git init -q')
+    run('git config user.email test@test.com')
+    run('git config user.name Test')
+    run('git add -A')
+    run('git commit -q -m mirror')
+    commit = execSync('git rev-parse HEAD', { cwd: valley }).toString().trim()
+    writeWatermark(valley, commit)
+  }
+
+  return { root, home, valley, mirror, live, commit }
+}
+
+function writeWatermark(valley, commit) {
+  fs.writeFileSync(
+    path.join(valley, '.wildflower-state.json'),
+    JSON.stringify({ commit, sownAt: '2026-01-01T00:00:00.000Z', wildflowerVersion: 'test' }, null, 2) + '\n'
+  )
+}
+
+function runStatus({ valley, home }, args = []) {
+  const res = spawnSync(process.execPath, [CLI, 'status', ...args], {
+    env: { ...process.env, VALLEY_PATH: valley, HOME: home },
+    encoding: 'utf8',
+  })
+  return { code: res.status, stdout: res.stdout, stderr: res.stderr }
+}
+
+// Parse --porcelain output into { path: state }, keyed by basename.
+function states(stdout) {
+  const out = {}
+  for (const line of stdout.split('\n')) {
+    if (!line.trim()) continue
+    const [state, file] = line.split('\t')
+    out[path.basename(file)] = state
+  }
+  return out
+}
+
+// Move each file into the state named after it: the mirror moves on for
+// `behind`, the live file moves for `ahead`, and `gone` disappears from live.
+function diverge(env) {
+  fs.writeFileSync(path.join(env.mirror, 'behind.txt'), 'v2\n')
+  fs.writeFileSync(path.join(env.live, 'ahead.txt'), 'local\n')
+  fs.rmSync(path.join(env.live, 'gone.txt'))
+}
+
+describe('wildflower status', () => {
+  it('reports every tracked file synced right after a sow', () => {
+    const env = setup()
+    const { code, stdout } = runStatus(env, ['--porcelain'])
+    assert.equal(stdout.trim(), '', 'porcelain should list nothing when all synced')
+    assert.equal(code, 0)
+  })
+
+  it('classifies ahead, behind and missing, and exits 1 for ahead', () => {
+    const env = setup()
+    diverge(env)
+    const { code, stdout } = runStatus(env, ['--porcelain'])
+    assert.deepEqual(states(stdout), {
+      'ahead.txt': 'ahead',
+      'behind.txt': 'behind',
+      'gone.txt': 'missing',
+    })
+    assert.equal(code, 1, 'an ahead file must exit 1 so the update script refuses')
+  })
+
+  it('exits 0 when nothing is ahead, even with behind and missing files', () => {
+    const env = setup()
+    fs.writeFileSync(path.join(env.mirror, 'behind.txt'), 'v2\n')
+    fs.rmSync(path.join(env.live, 'gone.txt'))
+    const { code, stdout } = runStatus(env, ['--porcelain'])
+    assert.deepEqual(states(stdout), { 'behind.txt': 'behind', 'gone.txt': 'missing' })
+    assert.equal(code, 0)
+  })
+
+  it('reports unknown rather than guessing when there is no watermark', () => {
+    const env = setup()
+    diverge(env)
+    fs.rmSync(path.join(env.valley, '.wildflower-state.json'))
+    const { code, stdout, stderr } = runStatus(env, ['--porcelain'])
+    assert.deepEqual(states(stdout), {
+      'ahead.txt': 'unknown',
+      'behind.txt': 'unknown',
+      'gone.txt': 'missing',
+    })
+    assert.equal(code, 0, 'unknown is not ahead, so it does not block')
+    assert.equal(stderr, '', 'porcelain stays quiet; the warning is human-mode only')
+  })
+
+  it('reports unknown when the watermark commit is unreachable', () => {
+    const env = setup()
+    diverge(env)
+    writeWatermark(env.valley, '0'.repeat(40))
+    const { stdout } = runStatus(env, ['--porcelain'])
+    assert.deepEqual(states(stdout), {
+      'ahead.txt': 'unknown',
+      'behind.txt': 'unknown',
+      'gone.txt': 'missing',
+    })
+  })
+
+  it('warns about a missing watermark in human output', () => {
+    const env = setup()
+    diverge(env)
+    fs.rmSync(path.join(env.valley, '.wildflower-state.json'))
+    const { stdout, stderr } = runStatus(env)
+    assert.match(stdout, /4 tracked, 1 synced, 0 ahead, 0 behind, 1 missing, 2 unknown/)
+    assert.match(stderr, /no watermark/)
+  })
+
+  it('narrows to a named path', () => {
+    const env = setup()
+    diverge(env)
+    const { code, stdout } = runStatus(env, ['--porcelain', path.join(env.live, 'behind.txt')])
+    assert.deepEqual(states(stdout), { 'behind.txt': 'behind' })
+    assert.equal(code, 0, 'the ahead file was not asked about')
+  })
+
+  it('exits 2 for a path no meadow covers', () => {
+    const env = setup()
+    const { code, stderr } = runStatus(env, ['--porcelain', path.join(env.home, 'not-tracked')])
+    assert.equal(code, 2)
+    assert.match(stderr, /not in meadows\.mjs/)
+  })
+
+  it('exits 2 when the valley is not a git repo', () => {
+    const env = setup({ git: false })
+    const { code, stderr } = runStatus(env, ['--porcelain'])
+    assert.equal(code, 2)
+    assert.match(stderr, /not a git repo/)
+  })
+
+  it('emits the watermark, counts and every file under --json', () => {
+    const env = setup()
+    diverge(env)
+    const { stdout } = runStatus(env, ['--json'])
+    const parsed = JSON.parse(stdout)
+    assert.equal(parsed.watermark, env.commit)
+    assert.deepEqual(parsed.counts, { ahead: 1, unknown: 0, behind: 1, missing: 1, synced: 1 })
+    assert.equal(parsed.files.length, 4, '--json reports synced files too')
+  })
+})

--- a/test/writeSyncMetadata.test.js
+++ b/test/writeSyncMetadata.test.js
@@ -15,11 +15,15 @@ fs.writeFileSync(path.join(tmpGit, 'meadows.mjs'), 'export const meadows = []\n'
 
 process.env.VALLEY_PATH = tmpGit
 
-const { writeSyncMetadata } = await import('../common.js')
+const { writeSyncMetadata, getValleyDir, getWatermarkDir } = await import('../common.js')
 
 describe('writeSyncMetadata', () => {
   after(() => {
     fs.rmSync(tmpGit, { recursive: true, force: true })
+  })
+
+  it('keeps the watermark in the valley itself for a plain checkout', () => {
+    assert.equal(getWatermarkDir(), getValleyDir(), 'existing hosts must see no change')
   })
 
   it('writes JSON with commit, sownAt, wildflowerVersion', () => {
@@ -42,5 +46,49 @@ describe('writeSyncMetadata', () => {
     assert.doesNotThrow(() => writeSyncMetadata())
     fs.rmSync(nonGit, { recursive: true, force: true })
     process.env.VALLEY_PATH = tmpGit
+  })
+})
+
+// All worktrees of a valley deliver to the same home directory, so they must
+// share one watermark. Resolved from a linked worktree, both the read and the
+// write have to land on the main checkout's copy rather than minting a private
+// one that leaves the main checkout's copy silently stale.
+// Its own repo rather than tmpGit: node:test runs each describe's after() before
+// the next describe's before(), so sharing tmpGit would hand this suite a
+// directory the first suite had already removed.
+describe('getWatermarkDir from a linked worktree', () => {
+  const scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'wf-test-wt-'))
+  const mainCheckout = path.join(scratch, 'main')
+  const wtPath = path.join(scratch, 'session')
+  let wt
+
+  before(async () => {
+    const run = (cmd, cwd) => execSync(cmd, { cwd, stdio: 'ignore' })
+    fs.mkdirSync(mainCheckout)
+    run('git init -q', mainCheckout)
+    run('git config user.email test@test.com', mainCheckout)
+    run('git config user.name Test', mainCheckout)
+    run('git commit -q --allow-empty -m init', mainCheckout)
+    run(`git worktree add -q -b session ${JSON.stringify(wtPath)}`, mainCheckout)
+    process.env.VALLEY_PATH = wtPath
+    // A fresh module instance: getValleyDir() caches, so the already-imported
+    // copy is pinned to tmpGit. The query string is what makes it fresh.
+    wt = await import('../common.js?worktree')
+  })
+
+  after(() => {
+    process.env.VALLEY_PATH = tmpGit
+    fs.rmSync(scratch, { recursive: true, force: true })
+  })
+
+  it('resolves to the main checkout, not the worktree', () => {
+    assert.equal(fs.realpathSync(wt.getValleyDir()), fs.realpathSync(wtPath))
+    assert.equal(fs.realpathSync(wt.getWatermarkDir()), fs.realpathSync(mainCheckout))
+  })
+
+  it('writes the main checkout watermark and leaves none in the worktree', () => {
+    wt.writeSyncMetadata()
+    assert.ok(fs.existsSync(path.join(mainCheckout, '.wildflower-state.json')), 'main checkout gets the watermark')
+    assert.ok(!fs.existsSync(path.join(wtPath, '.wildflower-state.json')), 'worktree gets no private copy')
   })
 })

--- a/wildflower.js
+++ b/wildflower.js
@@ -6,6 +6,7 @@ import { gather } from "./gather.js";
 import { till } from "./till.js";
 import { pathCmd } from "./path.js";
 import { diff } from "./diff.js";
+import { status } from "./status.js";
 import packageJson from './package.json' with { type: 'json' };
 
 updateNotifier({ pkg: packageJson }).notify()
@@ -18,6 +19,7 @@ Commands:
   gather [<path>...]   Copy live FS → meadows. With no args, wholesale.
   sow    [<path>...]   Copy meadows → live FS. With no args, wholesale.
   diff   [<path>...]   Report live-vs-meadows divergence. Read-only.
+  status [<path>...]   Classify tracked paths against the sync watermark.
   path   <path>...     Map a tracked path between live FS and meadows form.
   till                 Initialize a sample meadows.mjs.
   version              Print version.
@@ -47,6 +49,30 @@ never mutates. Honors each meadow's filter, so excluded paths (e.g.
               report which files differ).
 
 Exit codes: 0 = identical, 1 = differ, 2 = path not tracked / error.`,
+  status: `wildflower status [<path>...] [--porcelain|--json]
+
+Classify each tracked path against the sync watermark (.wildflower-state.json,
+the commit the live filesystem was last sown to). Read-only; never mutates.
+Where diff reports that two files differ, status reports which side moved:
+
+  synced    live content equals the mirror
+  behind    live differs from the mirror but matches the watermark's blob, so
+            the mirror moved on and live is merely un-sown
+  ahead     live differs from both, so it was edited live since the last sow
+  missing   the mirror tracks it, the live filesystem doesn't have it
+  unknown   no watermark, or the watermark commit is unreachable
+
+Honors each meadow's filter and \`if\` condition. Files are enumerated from the
+mirror, so a live-only file that was never gathered is out of scope (sow won't
+touch it either); use \`diff\` to see those. With no <path>, checks every meadow.
+
+  --porcelain   Emit \`STATE<tab>path\`, listing only paths that aren't synced.
+  --json        Emit the watermark, the state counts, and every tracked path.
+
+Default output lists the paths that aren't synced, then a count line.
+
+Exit codes: 0 = nothing ahead, 1 = at least one path ahead, 2 = a named path
+isn't tracked / the valley isn't a git repo.`,
   path: `wildflower path <path>...
 
 Map tracked path(s) between live-FS form and meadows-mirror form. Pure: reads
@@ -79,6 +105,11 @@ if (command && COMMAND_HELP[command] && wantsHelp(rest)) {
   const verbose = rest.includes('--verbose')
   const paths = rest.filter((a) => a !== '--verbose')
   await diff(paths.length > 0 ? paths : null, { verbose })
+} else if (command === 'status') {
+  const porcelain = rest.includes('--porcelain')
+  const json = rest.includes('--json')
+  const paths = rest.filter((a) => a !== '--porcelain' && a !== '--json')
+  await status(paths.length > 0 ? paths : null, { porcelain, json })
 } else if (command === 'version' || command === '--version' || command === '-v') {
   console.log(VERSION)
 } else if (command === 'help' || command === '--help' || command === '-h') {


### PR DESCRIPTION
Adds a `status` subcommand and fixes the watermark's identity. Cut as 3.2.0: minor for the new subcommand, and the watermark fix is a no-op on a plain checkout.

## `wildflower status`

`diff` answers "do these two files differ." That is not enough to decide what to do about it, because a difference means either the mirror moved on and the live file is merely un-sown, or someone edited the live file since the last sow. Those want opposite remedies, and picking wrong destroys work either way.

`status` brings the sync watermark in as a third input and treats it as a merge base:

| State | Condition |
| --- | --- |
| `synced` | live content equals the mirror |
| `behind` | live differs from the mirror but matches the watermark's blob for that path |
| `ahead` | live differs from both |
| `missing` | the mirror tracks it, the live filesystem doesn't have it |
| `unknown` | no watermark, or the watermark commit is unreachable |

Exit 0 when nothing is `ahead`, 1 when something is, 2 when a named path isn't tracked or the valley isn't a git repo. That exit code is the point: it makes `status` usable as a pre-flight by a caller about to overwrite live files from the mirror. `--porcelain` emits `STATE<tab>path` for what isn't clean; `--json` emits the watermark, the counts, and every tracked path.

`unknown` is deliberate rather than a fallback guess. A rebase can orphan the recorded commit, and the honest answer there is "cannot tell," not a coin flip.

Files are enumerated from the mirror, so a live-only file that was never gathered is out of scope. `sow` won't touch such a file either, and reporting it would make the pre-flight a permanent blocker on any host that has one. `diff` still shows them.

Two implementation notes. Blob ids are computed in process, because one `git hash-object` spawn per file dominates the run at a few thousand tracked paths; the real valley this was built for has 326. The watermark's blobs come from a single `git ls-tree` rather than a `git rev-parse <commit>:<path>` per file. Symlinks hash their target string, which is what git stores for them, so a tracked symlink compares correctly on both sides.

## Watermark identity

`writeSyncMetadata()` wrote to `getValleyDir()` and read `HEAD` from that same directory. All worktrees of a valley deliver to one home directory, so pointing `VALLEY_PATH` at a session worktree — which the per-file gather workflow actively teaches — gave that worktree a private watermark while the main checkout's copy went silently stale.

`getWatermarkDir()` resolves the main checkout via `git rev-parse --git-common-dir`. On a plain checkout it returns the valley itself, so existing hosts see a byte-identical path and there is no migration.

For the same reason, a wholesale `sow` now refuses to run from a linked worktree and exits 2 naming the main checkout. It would otherwise stamp the watermark with a session-branch commit that landing is about to rewrite into new SHAs and then delete, leaving the watermark pointing at a commit no branch reaches. The refusal happens before anything is copied. Per-file `sow` is unaffected, since it returns earlier and never touches the watermark.

## Incidental

`relUnder` moves from `diff.js` to `common.js`, with `diff.js` re-exporting it. Importing `diff.js` from `status.js` would have run `diff.js`'s module-level `runDirectly()` block, executing a diff and calling `process.exit()` before `status.js` ever started.

`status` sets `process.exitCode` instead of calling `process.exit()`. stdout is async when it is a pipe, and `process.exit()` drops whatever is still buffered — `--json` against a real valley came back truncated mid-object.

## Testing

`npm test`, 39 passing. `test/status.test.js` covers all five states plus a missing watermark, an unreachable watermark commit, path narrowing, both exit-2 cases, and the `--json` shape; each case runs the real CLI in a child process with its own `VALLEY_PATH` and `HOME`, so the exit codes are exercised rather than asserted about. `test/writeSyncMetadata.test.js` gains a linked-worktree suite asserting the read and the write both land on the main checkout, and that a plain checkout still resolves to the valley itself.

Run against the valley this was built for: 326 tracked, 326 synced, exit 0, in under two seconds.

## Known gap

`package-lock.json` still records 3.1.0, having missed the 3.1.1 bump as well. Left alone rather than mixed into this change.
