### PR TITLE
Add per-host branching (by) to meadows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ## Basic usage:
+
 ### First time users
 
 1. Install node.
@@ -16,7 +17,9 @@
 4. Run `wildflower sow` to distribute your config files.
 
 ## Valleys
+
 The filesystem you should have after tilling will look something like:
+
 ```
 .../
   valley/        # choose where you want to root this directory by running till from ...
@@ -32,7 +35,7 @@ A valley (the folder where your meadows are) can be located in one of three plac
 
 After every `sow`, wildflower writes `.wildflower-state.json` at the valley root, recording the commit the live filesystem was synced to. It is per-machine state: if you version your valley with git, ignore this file.
 
-If your valley is a git repo, that recorded commit is the **merge base** when the live filesystem and the mirror diverge. The base turns an ambiguous live-vs-`HEAD` diff into a well-defined 3-way merge (base = last-sown commit, *ours* = live FS, *theirs* = current `HEAD`):
+If your valley is a git repo, that recorded commit is the **merge base** when the live filesystem and the mirror diverge. The base turns an ambiguous live-vs-`HEAD` diff into a well-defined 3-way merge (base = last-sown commit, _ours_ = live FS, _theirs_ = current `HEAD`):
 
 | live vs base | HEAD vs base | meaning | action |
 | --- | --- | --- | --- |
@@ -55,17 +58,19 @@ git merge-file ~/.someconfig /tmp/wf-base /tmp/wf-theirs   # edits ~/.someconfig
 
 You can currently define two types of meadows: `path`s, which allow you to easily copy and manage files and folders, and `run`s, which allow you to run arbitrary commands.
 
-### Copying files 
+### Copying files
 
 You can copy either files or folders by setting a `path` property that defines where on disk to find the files to copy. In the case of folders, you can filter out the contents using globs.
 
 Example copying files:
+
 ```js
 { path: `~/Library/Preferences/at.obdev.LaunchBar.plist` },
 { path: `~/Library/Preferences/at.obdev.LaunchBar.ActionEditor.plist` },
 ```
 
 Example copying folders:
+
 ```js
 {
   path: `~/Library/Application Support/LaunchBar`,
@@ -77,7 +82,7 @@ Example copying folders:
     // if you're using git to store these, you can skip the directory ignore
     '!**/node_modules',
     '!**/node_modules/**',
-    
+
     // note specific files
     `!Habits.plist`,
     `!Recent Documents.plist`
@@ -87,7 +92,7 @@ Example copying folders:
 
 ### Running functions
 
-You can run arbitrary javascript (and therefore shell commands) to perform some task using the `gather` and `sow` properties, which run on their respective wildflower commands. 
+You can run arbitrary javascript (and therefore shell commands) to perform some task using the `gather` and `sow` properties, which run on their respective wildflower commands.
 
 `zsh`, `bash`, `shell`, and `run` functions are provided globally to allow for easy shell access.
 
@@ -109,12 +114,52 @@ When combined with paths, both `gather` and `sow` recieve the paths of the final
 
 ```js
 {
-  path: '/path/to/folder'
+  path: "/path/to/folder",
   gather: (arrayOfFilesWeCopied) => {
-    console.log(arrayOfFilesWeCopied)
-  }
+    console.log(arrayOfFilesWeCopied);
+  },
 }
 ```
+
+### Per-host variants (`by`)
+
+A meadow can declare `by: () => string | undefined | Promise<string | undefined>` to keep more than one variant of the same file side by side in the mirror -- most commonly, one variant per host. `by` may be sync or async, and can call out to `bash`/`zsh`/`shell`/`run` (or the `hostname` global below) to compute its key.
+
+```js
+{ path: '~/.gitconfig', by: () => hostname() },
+```
+
+When a meadow has `by`, its mirror-side root gets a `~by~/<key>/` segment spliced in, so each key's variant lands in its own untouched corner of the mirror:
+
+```
+meadows/~by~/stockholm/~~/.gitconfig
+meadows/~by~/heron/~~/.gitconfig
+```
+
+Both are committed side by side in the same repo; nothing is overwritten switching hosts.
+
+The resolved key is trimmed and validated before use: it can't be empty, can't contain `/` or `..`, and can't collide with the reserved segment names `~by~`, `~~`, or `~default`. A `by` function is memoized once per run -- meadows that share the exact same function reference only evaluate it once.
+
+**`by` is not a secrecy mechanism.** Every host's variant is committed to the same shared repo, readable by anyone with access to it -- `by` only keeps variants from colliding, it does not hide them from each other. If something shouldn't be committed at all (a token file, a machine-specific secret), use `filter` to exclude it (e.g. `!*-tokens.json`), the same as any other meadow.
+
+`wildflower path` and `wildflower diff` treat an explicitly-named key as inspectable -- naming another host's mirror path (e.g. `wildflower diff meadows/~by~/heron/~~/.gitconfig`) resolves and diffs it against your live file, whichever key it names. `wildflower gather` and `wildflower sow`, by contrast, only ever read or write _this host's own_ resolved key -- naming another host's mirror path as a gather/sow target is equivalent to naming its live-FS path; it never reads or writes anyone else's variant.
+
+#### The `~default` fallback
+
+If `by()` returns `undefined` (or `null`) -- rather than a string -- that's read as "this meadow branches, but I have no identity for this host right now." The cleanest way to get that for free is a lookup table: any host not listed just falls out the bottom as `undefined`, no extra logic required.
+
+```js
+const hostVariants = { stockholm: 'stockholm', heron: 'heron' }
+by: () => hostVariants[hostname()],
+```
+
+When that happens, `sow` reads from a fixed, reserved subtree, `~by~/~default/`, if something exists there -- and always says so explicitly ("using the shared `~default` variant"), so it's never a silent substitution. If nothing exists there either, `sow` prints the same kind of "nothing to sow" message it always has.
+
+**`~default` is populated only by hand, never by wildflower.** No `gather` -- targeted or wholesale, on any host, under any `by()` outcome -- ever writes to `~by~/~default/`. It's an ordinary path in the git-tracked mirror; put something there the same way you'd populate any other tracked file, for instance by copying an existing host's already-gathered subtree once: `cp -r meadows/~by~/stockholm meadows/~by~/~default`. `~default` is also a reserved segment name, so a resolver can never accidentally (or deliberately) return the literal string `'~default'` as an ordinary key -- the fallback can only ever be reached through the `undefined` signal.
+
+#### The `hostname` global
+
+Alongside `bash`, `zsh`, `shell`, and `run`, meadows.mjs has a `hostname()` global -- a thin wrapper around `os.hostname()` that strips a trailing `.local` (which macOS/mDNS commonly appends but Linux/WSL typically don't, so the same physical machine resolves to one key on either platform). Write your own resolver instead if you want the raw value or something else entirely.
 
 ## Targeted (per-file) operations
 
@@ -134,6 +179,7 @@ wildflower diff                            # all meadows
 ```
 
 Targeted operations:
+
 - Skip meadow-level `if` conditions and `meadow.gather()` / `meadow.sow()` callbacks (those are whole-meadow semantics; the user named the file explicitly).
 - Ignore meadow filters when an explicit path is given. Filters exist to restrict wholesale recursion; when a path is named on the CLI, it's gathered/sowed as-is.
 - Preserve symlinks (`expand: false` in both directions).
@@ -157,6 +203,7 @@ Exits non-zero if the path isn't covered by any meadow.
 ## `wildflower diff`
 
 Reports divergence between live FS and the meadows mirror. Read-only; never mutates. Exit codes:
+
 - `0` — all checked paths identical
 - `1` — at least one divergence
 - `2` — at least one path not tracked, or other error
@@ -164,9 +211,10 @@ Reports divergence between live FS and the meadows mirror. Read-only; never muta
 Implementation delegates to `diff -rq` per pair.
 
 ## Todo:
-- Add ability for wildflower to run commands 
+
+- Add ability for wildflower to run commands
   - Note that the `sow` step current runs commands, but the `gather` step does not.
-- Add some kind of ordering/dependency mechanism (wait for 'x' before doing 'y'.) 
+- Add some kind of ordering/dependency mechanism (wait for 'x' before doing 'y'.)
   - Note that the `sow` step runs in sequence, but the `gather` step runs in parallel.
 - Improve runtime perf (parallelize async fs operations)
 - Add runtime perf / debugging utilities

--- a/common.js
+++ b/common.js
@@ -1,4 +1,5 @@
 import path from 'node:path'
+import os from 'node:os'
 import { spawn, execSync } from 'node:child_process'
 import fs from 'fs'
 import { cp, readdir, stat, statfs } from 'node:fs/promises';
@@ -113,11 +114,23 @@ export function fixInstalledPath(filepath) {
   return filepath
 }
 
-export function fixSourceControlPath(filepath) {
+export function fixSourceControlPath(filepath, branchKey) {
   // transform ~/ into ~~/ for safety
   if (filepath.length && filepath.startsWith(process.env['HOME'])) filepath = "~" + filepath.slice(process.env['HOME'].length)
   if (filepath.length && filepath[0] == `~`) filepath = `~${filepath}`
-  return path.join(getValleyDir(), "/meadows", filepath)
+  // A *two-argument* call with branchKey === undefined means "branching,
+  // but no identity this run" (see resolveBranchKey) -- route it to the
+  // reserved '~default' subtree. Omitting the argument entirely, or
+  // passing null explicitly, means "not branching at all" -- no ~by~
+  // prefix, same as today. These must be told apart by arity (via
+  // `arguments.length`), not a `branchKey = null` default parameter:
+  // JS defaults trigger identically for an omitted argument and an
+  // explicitly-passed `undefined`, which would silently collapse
+  // resolveBranchKey's real "no identity" signal back into "not
+  // branching" -- exactly the bug this arity check avoids.
+  const effectiveKey = arguments.length >= 2 && branchKey === undefined ? '~default' : branchKey
+  const branchPrefix = effectiveKey ? path.join('~by~', effectiveKey) : ''
+  return path.join(getValleyDir(), "/meadows", branchPrefix, filepath)
 }
 
 /**
@@ -135,9 +148,22 @@ export function findMeadowForPath(targetPath, meadows) {
 
   // If the path is under the meadows/ mirror, map it back to the live FS
   // equivalent first so the lookup logic is single-pass.
+  let foreignBranchKey = null
   if (abs === meadowsRoot || abs.startsWith(meadowsRoot + '/')) {
     let mirrorRel = abs.slice(meadowsRoot.length).replace(/^\/+/, '')
-    // mirrorRel looks like '~~/.zshrc' — strip one `~` so we have `~/.zshrc`
+    // Transparently strip a `~by~/<key>/` branch prefix, capturing
+    // whichever key it named -- regardless of whether it matches this
+    // host's own resolved key. Reads (path/diff) may use the captured key
+    // to inspect a foreign host's committed variant explicitly; gather/sow
+    // (copyPath) MUST NEVER read this field -- they always resolve their
+    // own key via resolveBranchKey(meadow) instead. This is the
+    // read/write safety split the whole feature depends on.
+    const byMatch = mirrorRel.match(/^~by~\/([^/]+)\//)
+    if (byMatch) {
+      foreignBranchKey = byMatch[1]
+      mirrorRel = mirrorRel.slice(byMatch[0].length)
+    }
+    // mirrorRel looks like '~~/.zshrc' -- strip one `~` so we have `~/.zshrc`
     if (mirrorRel.startsWith('~~')) mirrorRel = mirrorRel.slice(1)
     abs = fixInstalledPath(mirrorRel)
   }
@@ -157,7 +183,7 @@ export function findMeadowForPath(targetPath, meadows) {
     }
   }
   if (!bestMeadow) return null
-  return { meadow: bestMeadow, installed: bestInstalled, absolute: abs }
+  return { meadow: bestMeadow, installed: bestInstalled, absolute: abs, foreignBranchKey }
 }
 
 /**
@@ -179,12 +205,17 @@ export async function mapPath(targetPath) {
   abs = path.resolve(abs)
 
   if (abs === meadowsRoot || abs.startsWith(meadowsRoot + '/')) {
-    // input is meadows-side → return live FS path
+    // input is meadows-side -> return live FS path
     return match.absolute
   }
-  // input is live FS → return meadow mirror path
+  // input is live FS -> return meadow mirror path, using this host's own
+  // resolved key (a live-FS input never carries a foreign key). If
+  // resolveBranchKey comes back undefined, this correctly reports the
+  // ~default location -- the only real location involved when there's no
+  // identity, even though `gather` (unlike `sow`) will refuse to use it.
   const rel = match.absolute.slice(match.installed.length)
-  return fixSourceControlPath(match.meadow.path) + rel
+  const branchKey = await resolveBranchKey(match.meadow)
+  return fixSourceControlPath(match.meadow.path, branchKey) + rel
 }
 
 // Evaluate a meadow's filter against a path relative to the meadow root. The
@@ -196,11 +227,86 @@ export function matchesFilter(filter, relPath) {
   return true
 }
 
+// Reserved mirror-side path segments a resolved `by` key must never
+// collide with. '~by~' and '~~' would corrupt path parsing if used as a
+// real key. '~default' is reserved so it can only ever be reached via
+// by() returning undefined/null (see resolveBranchKey) -- never via an
+// ordinary string -- which keeps "gather can never write to ~default"
+// true regardless of what any resolver's string output happens to be.
+const RESERVED_BRANCH_SEGMENTS = new Set(['~by~', '~~', '~default'])
+
+// Per-run memoization of `by` resolvers, keyed by function *reference*
+// (not resolved value): meadows sharing one resolver reference evaluate it
+// once; distinct references (even resolving to the same string) evaluate
+// independently. Caches the resolution promise itself so a slow/async
+// resolver shared by two meadows only ever runs once even if both are
+// awaited before the first resolves.
+const branchKeyCache = new Map()
+
+/**
+ * Resolve and memoize a meadow's `by` resolver. Three possible outcomes:
+ *   - null: the meadow has no `by` at all -- not branching.
+ *   - undefined: the meadow has `by`, and it resolved to undefined/null --
+ *     a deliberate "no identity for this host, right now" signal. sow
+ *     falls back to the fixed '~default' subtree if one exists (see
+ *     resolveSowSource); gather refuses outright, since there's nowhere
+ *     safe for it to write.
+ *   - a validated non-empty string: an ordinary per-host key.
+ * Rejects if by() throws, or resolves to a defined value that, once
+ * trimmed, is empty, contains '/' or '..', or collides with a reserved
+ * segment name.
+ */
+export async function resolveBranchKey(meadow) {
+  if (!meadow.by) return null
+
+  if (!branchKeyCache.has(meadow.by)) {
+    branchKeyCache.set(meadow.by, (async () => {
+      if (typeof meadow.by !== 'function') {
+        throw new Error(`meadow.by must be a function (got ${typeof meadow.by})`)
+      }
+      const raw = await meadow.by()
+      if (raw === undefined || raw === null) return undefined
+
+      const key = String(raw).trim()
+      if (key === '') {
+        throw new Error(`meadow.by() resolved to an empty key`)
+      }
+      if (key.includes('/')) {
+        throw new Error(`meadow.by() resolved to an invalid key '${key}': must not contain '/'`)
+      }
+      if (key.includes('..')) {
+        throw new Error(`meadow.by() resolved to an invalid key '${key}': must not contain '..'`)
+      }
+      if (RESERVED_BRANCH_SEGMENTS.has(key)) {
+        throw new Error(`meadow.by() resolved to an invalid key '${key}': collides with a reserved wildflower path segment`)
+      }
+      return key
+    })())
+  }
+
+  return branchKeyCache.get(meadow.by)
+}
+
+// Given a meadow and its resolveBranchKey() outcome, decide what `sow`
+// should read from, and whether it's actually there. branchKey undefined
+// routes to the fixed '~default' subtree (see resolveBranchKey and the
+// RESERVED_BRANCH_SEGMENTS comment above for why gather can never have put
+// anything there itself). branchKey a string, or null (unbranched),
+// resolves to that key's/plain's own path, unchanged from today.
+export function resolveSowSource(meadow, branchKey) {
+  const from = fixSourceControlPath(meadow.path, branchKey)
+  return {
+    from,
+    usingDefault: branchKey === undefined,
+    exists: fs.existsSync(from),
+  }
+}
+
 // Copy a single tracked path (file or subtree) between the live filesystem and
-// its mirror. `direction` is 'gather' (live → mirror) or 'sow' (mirror → live);
+// its mirror. `direction` is 'gather' (live -> mirror) or 'sow' (mirror -> live);
 // `target` may be given in either live-FS or meadows-mirror form. Resolves the
 // owning meadow, honors that meadow's `if` condition and filter, then copies
-// only files under the target — leaving every other tracked file untouched, so
+// only files under the target -- leaving every other tracked file untouched, so
 // concurrent edits to other files don't bleed in. The per-meadow gather()/sow()
 // callbacks are intentionally skipped (whole-meadow semantics). Returns an exit
 // status (0 ok / 1 problem) rather than exiting, so callers can aggregate across
@@ -217,8 +323,30 @@ export async function copyPath(target, meadows, direction) {
 
   const shouldRun = meadow.if ? await meadow.if() : true
   if (!shouldRun) {
-    console.log(`Skipping '${absolute}' — ${meadowLabel(meadow, index)} condition didn't pass on this host.`)
+    console.log(`Skipping '${absolute}' -- ${meadowLabel(meadow, index)} condition didn't pass on this host.`)
     return 0
+  }
+
+  // SAFETY: always resolve *this host's own* branch key via
+  // resolveBranchKey(meadow) -- never match.foreignBranchKey (which
+  // findMeadowForPath captures purely for read-side commands like diff,
+  // see diff.js). Naming a foreign mirror path as a gather/sow target here
+  // is equivalent to naming its live-FS counterpart: it still only ever
+  // reads or writes this host's own branch subtree, never another host's.
+  let branchKey
+  try {
+    branchKey = await resolveBranchKey(meadow)
+  } catch (error) {
+    console.error(`Skipping '${absolute}' -- ${meadowLabel(meadow, index)} by() failed: ${error.message}`)
+    return 1
+  }
+
+  // SAFETY: gather can never target ~default. by() returning undefined means
+  // this host has no identity for this meadow right now -- there is nowhere
+  // safe to write, so refuse before any destination path is even computed.
+  if (direction === 'gather' && branchKey === undefined) {
+    console.error(`Skipping '${absolute}' -- ${meadowLabel(meadow, index)}'s by() returned no identity for this host; there is nowhere safe to gather to. (Only 'sow' can read the shared '~default' variant.)`)
+    return 1
   }
 
   // Path of the target relative to the meadow root (posix-style, as the meadow
@@ -238,7 +366,7 @@ export async function copyPath(target, meadows, direction) {
         const isTarget = norm === relTarget || norm.startsWith(relTarget + '/')
         const isAncestorDir = relTarget.startsWith(norm + '/')
         if (!isTarget && !isAncestorDir) return false
-        // Ancestor dirs only need traversal — skip the meadow filter for them.
+        // Ancestor dirs only need traversal -- skip the meadow filter for them.
         if (isAncestorDir && !isTarget) return true
       }
       // Honor the meadow's own include/exclude filter (e.g. !*-tokens.json).
@@ -248,14 +376,34 @@ export async function copyPath(target, meadows, direction) {
 
   // Copy from the meadow root (not the named subtree) so meadow-root-relative
   // filter globs evaluate correctly; the filter narrows to the target.
-  const from = direction === 'gather' ? fixInstalledPath(meadow.path) : fixSourceControlPath(meadow.path)
-  const to = direction === 'gather' ? fixSourceControlPath(meadow.path) : fixInstalledPath(meadow.path)
+  // SAFETY: `to`, for gather, is safe by construction -- the refusal check
+  // above already returned when branchKey === undefined, so branchKey here
+  // is guaranteed to be null or a valid string; fixSourceControlPath can
+  // never land on ~default for a gather.
+  const to = direction === 'gather' ? fixSourceControlPath(meadow.path, branchKey) : fixInstalledPath(meadow.path)
+
+  let from
+  if (direction === 'gather') {
+    from = fixInstalledPath(meadow.path)
+  } else {
+    const source = resolveSowSource(meadow, branchKey)
+    from = source.from
+    if (!source.exists) {
+      const reason = source.usingDefault ? `no '~default' variant exists yet` : `no '${branchKey}' branch has been gathered yet`
+      const hint = source.usingDefault ? '' : ` Run 'wildflower gather' on this host first.`
+      console.error(`Skipping '${absolute}' -- ${reason} for ${meadowLabel(meadow, index)}.${hint}`)
+      return 1
+    }
+    if (source.usingDefault) {
+      console.log(`${meadowLabel(meadow, index)}: by() returned no identity for this host; using the shared '~default' variant.`)
+    }
+  }
 
   try {
     const operations = await (meadow.curable ? curableCopy : copy)(from, to, options)
     const files = operations.filter((op) => op.stats?.isFile?.() ?? true)
     if (files.length === 0) {
-      console.error(`Nothing ${verb} for '${absolute}' — excluded by the ${meadowLabel(meadow, index)} filter?`)
+      console.error(`Nothing ${verb} for '${absolute}' -- excluded by the ${meadowLabel(meadow, index)} filter?`)
       return 1
     }
     for (const op of files) {
@@ -401,11 +549,27 @@ export async function run(
   })
 }
 
+// Exported separately so the trailing-.local rule is unit-testable without
+// mocking os.hostname().
+export function stripLocalSuffix(name) {
+  return name.endsWith('.local') ? name.slice(0, -'.local'.length) : name
+}
+
+// Convenience global for `by` resolvers: os.hostname() with a trailing
+// .local stripped (macOS/mDNS commonly appends it, Linux/WSL typically
+// don't -- stripping keeps the same physical host resolving to one key
+// regardless of platform). Write your own resolver if you want the raw
+// value instead.
+export function hostname() {
+  return stripLocalSuffix(os.hostname())
+}
+
 export async function parseMeadows() {
   global.bash = bash
   global.zsh = zsh
   global.shell = shell
   global.run = run
+  global.hostname = hostname
 
   const { meadows } = await import(path.join(getValleyDir(), './meadows.mjs'))
   return { meadows }

--- a/diff.js
+++ b/diff.js
@@ -3,7 +3,7 @@
 import { spawn } from 'node:child_process'
 import * as fs from 'node:fs'
 import path from 'node:path'
-import { parseMeadows, fixInstalledPath, fixSourceControlPath, findMeadowForPath, matchesFilter, runDirectly } from './common.js'
+import { parseMeadows, fixInstalledPath, fixSourceControlPath, findMeadowForPath, matchesFilter, runDirectly, resolveBranchKey, meadowLabel } from './common.js'
 
 /**
  * `wildflower diff [<path>...] [--verbose]` — report live FS vs meadows-mirror
@@ -39,11 +39,24 @@ export async function diff(targets = null, { verbose = false } = {}) {
         continue
       }
       const rel = match.absolute.slice(match.installed.length)
+      let branchKey
+      try {
+        // Honor a foreign key explicitly named in the target (e.g. a mirror
+        // path under ~by~/other-host/, or ~by~/~default/ itself); otherwise
+        // this host's own key (possibly undefined, which fixSourceControlPath
+        // below correctly routes to ~default too). copyPath (gather/sow)
+        // intentionally never does this.
+        branchKey = match.foreignBranchKey ?? await resolveBranchKey(match.meadow)
+      } catch (error) {
+        console.error(`Skipping '${target}': by() failed: ${error.message}`)
+        resolveErrors = 1
+        continue
+      }
       pairs.push({
         live: match.absolute,
-        meadow: fixSourceControlPath(match.meadow.path) + rel,
+        meadow: fixSourceControlPath(match.meadow.path, branchKey) + rel,
         root: match.installed,
-        mirrorRoot: fixSourceControlPath(match.meadow.path),
+        mirrorRoot: fixSourceControlPath(match.meadow.path, branchKey),
         filter: match.meadow.filter,
       })
     }
@@ -51,13 +64,20 @@ export async function diff(targets = null, { verbose = false } = {}) {
       process.exit(2)
     }
   } else {
-    for (const meadow of meadows) {
+    for (const [index, meadow] of Object.entries(meadows)) {
       if (!meadow.path) continue
+      let branchKey
+      try {
+        branchKey = await resolveBranchKey(meadow)
+      } catch (error) {
+        console.error(`Skipping ${meadowLabel(meadow, index)}: by() failed: ${error.message}`)
+        continue
+      }
       pairs.push({
         live: fixInstalledPath(meadow.path),
-        meadow: fixSourceControlPath(meadow.path),
+        meadow: fixSourceControlPath(meadow.path, branchKey),
         root: path.resolve(fixInstalledPath(meadow.path)),
-        mirrorRoot: fixSourceControlPath(meadow.path),
+        mirrorRoot: fixSourceControlPath(meadow.path, branchKey),
         filter: meadow.filter,
       })
     }

--- a/gather.js
+++ b/gather.js
@@ -2,7 +2,7 @@
 
 import copy from 'recursive-copy'
 import * as fs from 'node:fs'
-import { parseMeadows, meadowLabel, curableCopy, copyPath } from './common.js'
+import { parseMeadows, meadowLabel, curableCopy, copyPath, resolveBranchKey } from './common.js'
 import { fixInstalledPath, fixSourceControlPath, logNoSuchFile, buildCopyOptions, runDirectly } from './common.js'
 
 export async function gather(targets = null) {
@@ -36,7 +36,25 @@ export async function gather(targets = null) {
 
   try {
     for (const [index, meadow] of Object.entries(meadows)) {
-      let shouldGather = meadow.if ? await meadow.if?.() : true
+      let shouldGather
+      let branchKey
+      try {
+        shouldGather = meadow.if ? await meadow.if?.() : true
+        branchKey = shouldGather ? await resolveBranchKey(meadow) : null
+      } catch (error) {
+        console.error(`ERROR: ${meadowLabel(meadow, index)} -- 'if' or 'by' threw before this meadow could run; skipping just this meadow.`)
+        console.error(error)
+        continue
+      }
+
+      // SAFETY: same refusal as copyPath (see common.js) -- gather never
+      // writes to ~default. Checked before capableOfGather so the "isn't
+      // capable of it" message below can't mask this case.
+      if (shouldGather && branchKey === undefined) {
+        console.log(`Skipping ${meadowLabel(meadow, index)} -- by() returned no identity for this host; nothing to gather into.`)
+        continue
+      }
+
       let capableOfGather = Boolean(meadow.path) || Boolean(meadow.gather)
       if (shouldGather && capableOfGather) {
         let copiedFiles
@@ -45,14 +63,14 @@ export async function gather(targets = null) {
           try {
             let operations = await (meadow.curable ? curableCopy : copy)(
               fixInstalledPath(meadow.path),
-              fixSourceControlPath(meadow.path),
+              fixSourceControlPath(meadow.path, branchKey),
               buildCopyOptions(copyOptions, meadow)
             )
-            
+
             // possibly there's a bug where the operation doesn't work
             copiedFiles = operations.map(operation => operation.dest)
 
-            console.log(`Copied '${fixInstalledPath(meadow.path)}' to '${fixSourceControlPath(meadow.path)}'`)
+            console.log(`Copied '${fixInstalledPath(meadow.path)}' to '${fixSourceControlPath(meadow.path, branchKey)}'`)
           } catch (e) {
             logNoSuchFile(e)
           }

--- a/sow.js
+++ b/sow.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import copy from 'recursive-copy'
-import { fixInstalledPath, fixSourceControlPath, logNoSuchFile, buildCopyOptions, parseMeadows, runDirectly, meadowLabel, curableCopy, copyPath, writeSyncMetadata } from './common.js'
+import { fixInstalledPath, fixSourceControlPath, logNoSuchFile, buildCopyOptions, parseMeadows, runDirectly, meadowLabel, curableCopy, copyPath, writeSyncMetadata, resolveBranchKey, resolveSowSource } from './common.js'
 
 export async function sow(targets = null) {
   const { meadows } = await parseMeadows()
@@ -34,25 +34,44 @@ export async function sow(targets = null) {
 
   try {
     for (const [index, meadow] of Object.entries(meadows)) {
-      let shouldSow = meadow.if ? await meadow.if?.() : true
+      let shouldSow
+      let branchKey
+      try {
+        shouldSow = meadow.if ? await meadow.if?.() : true
+        branchKey = shouldSow ? await resolveBranchKey(meadow) : null
+      } catch (error) {
+        console.error(`ERROR: ${meadowLabel(meadow, index)} -- 'if' or 'by' threw before this meadow could run; skipping just this meadow.`)
+        console.error(error)
+        continue
+      }
       let capableOfSow = Boolean(meadow.path) || Boolean(meadow.sow)
       if (shouldSow && capableOfSow) {
         let copiedFiles
 
         // We could, if we wanted to get smart, throw files together in a batch, then trigger them asynchronously.
         if (meadow.path) {
-          try {
-            let operations = await (meadow.curable ? curableCopy : copy)(
-              fixSourceControlPath(meadow.path),
-              fixInstalledPath(meadow.path),
-              buildCopyOptions(copyOptions, meadow)
-            )
+          const source = resolveSowSource(meadow, branchKey)
+          if (!source.exists) {
+            const reason = source.usingDefault ? `no '~default' variant exists yet` : `no '${branchKey}' branch has been gathered yet`
+            const hint = source.usingDefault ? '' : ` Run 'wildflower gather' first, then retry 'wildflower sow'.`
+            console.error(`Skipping ${meadowLabel(meadow, index)} -- ${reason} on this host.${hint}`)
+          } else {
+            if (source.usingDefault) {
+              console.log(`${meadowLabel(meadow, index)}: by() returned no identity for this host; using the shared '~default' variant.`)
+            }
+            try {
+              let operations = await (meadow.curable ? curableCopy : copy)(
+                source.from,
+                fixInstalledPath(meadow.path),
+                buildCopyOptions(copyOptions, meadow)
+              )
 
-            copiedFiles = operations.map(operation => operation.dest)
+              copiedFiles = operations.map(operation => operation.dest)
 
-            console.log(`Copied '${fixSourceControlPath(meadow.path)}' to '${fixInstalledPath(meadow.path)}'`)
-          } catch (error) {
-            logNoSuchFile(error)
+              console.log(`Copied '${source.from}' to '${fixInstalledPath(meadow.path)}'`)
+            } catch (error) {
+              logNoSuchFile(error)
+            }
           }
         }
 

--- a/test/by.test.js
+++ b/test/by.test.js
@@ -1,0 +1,100 @@
+import { describe, it, after } from 'node:test'
+import assert from 'node:assert/strict'
+import os from 'node:os'
+import path from 'node:path'
+import fs from 'node:fs'
+
+// Own tmp valley + real meadows.mjs, set once before the dynamic import --
+// getValleyDir() caches VALLEY_PATH at module scope for the life of the
+// process, and node --test runs each matched file in its own subprocess, so
+// a distinct on-disk valley needs a distinct file (same reason
+// writeSyncMetadata.test.js has its own file rather than sharing
+// common.test.js's already-locked-in VALLEY_PATH). The second meadow's by()
+// always returns undefined, simulating a host with no identity for that file.
+const tmpValley = fs.mkdtempSync(path.join(os.tmpdir(), 'wf-test-by-'))
+fs.mkdirSync(path.join(tmpValley, 'meadows'), { recursive: true })
+fs.writeFileSync(
+  path.join(tmpValley, 'meadows.mjs'),
+  `export const meadows = [
+    { path: '~/.gitconfig', by: () => 'current-host' },
+    { path: '~/.other-config', by: () => undefined },
+  ]\n`
+)
+
+// Pre-seed a *foreign* key's mirror subtree with different content, so
+// tests below can prove gather/sow never read or write it.
+const foreignDir = path.join(tmpValley, 'meadows', '~by~', 'other-host', '~~')
+fs.mkdirSync(foreignDir, { recursive: true })
+fs.writeFileSync(
+  path.join(foreignDir, '.gitconfig'),
+  'FOREIGN -- must never be read or written by this host\n'
+)
+
+// Pre-seed the current host's own subtree with different-again content, so
+// the sow test can distinguish "read the right thing" from "read nothing."
+const currentDir = path.join(tmpValley, 'meadows', '~by~', 'current-host', '~~')
+fs.mkdirSync(currentDir, { recursive: true })
+fs.writeFileSync(path.join(currentDir, '.gitconfig'), 'CURRENT HOST CONTENT\n')
+
+// Seed ~default by hand, exactly as a human would -- for the *second*
+// meadow (~/.other-config) only. This is the only way anything ever lands
+// here; no wildflower command populates it.
+const defaultDir = path.join(tmpValley, 'meadows', '~by~', '~default', '~~')
+fs.mkdirSync(defaultDir, { recursive: true })
+fs.writeFileSync(path.join(defaultDir, '.other-config'), 'DEFAULT CONTENT\n')
+
+process.env.VALLEY_PATH = tmpValley
+
+const { mapPath, copyPath, parseMeadows } = await import('../common.js')
+
+describe('by: forward mapping and gather/sow only ever target the current key', () => {
+  const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'wf-test-by-home-'))
+  const realHome = process.env.HOME
+
+  after(() => {
+    process.env.HOME = realHome
+    fs.rmSync(tmpValley, { recursive: true, force: true })
+    fs.rmSync(fakeHome, { recursive: true, force: true })
+  })
+
+  it('mapPath resolves to the current key subtree, never the foreign one already on disk', async () => {
+    process.env.HOME = fakeHome
+    const mapped = await mapPath(path.join(fakeHome, '.gitconfig'))
+    assert.equal(mapped, path.join(currentDir, '.gitconfig'))
+    assert.ok(!mapped.includes('other-host'), 'must never resolve into a foreign key subtree')
+  })
+
+  it('sowing the foreign mirror path as a target still only reads the current key (owned-write)', async () => {
+    process.env.HOME = fakeHome
+    const { meadows } = await parseMeadows()
+    const foreignMirrorPath = path.join(foreignDir, '.gitconfig')
+
+    await copyPath(foreignMirrorPath, meadows, 'sow')
+
+    const written = fs.readFileSync(path.join(fakeHome, '.gitconfig'), 'utf8')
+    assert.equal(written, 'CURRENT HOST CONTENT\n')
+  })
+
+  it('sow falls back to ~default for a meadow whose by() returns undefined', async () => {
+    process.env.HOME = fakeHome
+    const { meadows } = await parseMeadows()
+    const target = path.join(fakeHome, '.other-config')
+
+    await copyPath(target, meadows, 'sow')
+
+    const written = fs.readFileSync(target, 'utf8')
+    assert.equal(written, 'DEFAULT CONTENT\n')
+  })
+
+  it('gather refuses when by() returns undefined, and never writes to ~default', async () => {
+    process.env.HOME = fakeHome
+    const { meadows } = await parseMeadows()
+    const target = path.join(fakeHome, '.other-config')
+
+    fs.writeFileSync(target, 'SHOULD NEVER BE GATHERED\n')
+    await copyPath(target, meadows, 'gather')
+
+    const stillThere = fs.readFileSync(path.join(defaultDir, '.other-config'), 'utf8')
+    assert.equal(stillThere, 'DEFAULT CONTENT\n', 'gather must never overwrite ~default')
+  })
+})

--- a/test/common.test.js
+++ b/test/common.test.js
@@ -13,6 +13,10 @@ const {
   matchesFilter,
   buildCopyOptions,
   findMeadowForPath,
+  resolveBranchKey,
+  resolveSowSource,
+  hostname,
+  stripLocalSuffix,
 } = await import('../common.js')
 
 describe('meadowLabel', () => {
@@ -43,6 +47,107 @@ describe('fixSourceControlPath', () => {
     assert.ok(result.startsWith(os.tmpdir()), 'should be under valley dir')
     assert.ok(result.includes('meadows'), 'should be under meadows/')
     assert.ok(result.includes('~~'), 'should double-tilde HOME paths')
+  })
+})
+
+describe('fixSourceControlPath with a branch key', () => {
+  it('splices in ~by~/<key>/ before the ~~ wrap for a string key', () => {
+    const result = fixSourceControlPath(path.join(process.env.HOME, '.gitconfig'), 'stockholm')
+    assert.ok(result.includes(path.join('~by~', 'stockholm', '~~', '.gitconfig')))
+  })
+  it('routes an undefined key to the reserved ~default segment', () => {
+    const result = fixSourceControlPath(path.join(process.env.HOME, '.gitconfig'), undefined)
+    assert.ok(result.includes(path.join('~by~', '~default', '~~', '.gitconfig')))
+  })
+  it('is identical to the no-key form when branchKey is null or omitted', () => {
+    const omitted = fixSourceControlPath(path.join(process.env.HOME, '.gitconfig'))
+    const nulled = fixSourceControlPath(path.join(process.env.HOME, '.gitconfig'), null)
+    assert.equal(omitted, nulled)
+  })
+})
+
+describe('resolveBranchKey', () => {
+  it('returns null when the meadow has no by', async () => {
+    assert.equal(await resolveBranchKey({}), null)
+  })
+  it('trims a sync by()', async () => {
+    assert.equal(await resolveBranchKey({ by: () => '  heron  ' }), 'heron')
+  })
+  it('awaits an async by()', async () => {
+    assert.equal(await resolveBranchKey({ by: async () => 'heron' }), 'heron')
+  })
+  it('resolves to undefined when by() returns undefined', async () => {
+    assert.equal(await resolveBranchKey({ by: () => undefined }), undefined)
+  })
+  it('resolves to undefined when by() returns null', async () => {
+    assert.equal(await resolveBranchKey({ by: () => null }), undefined)
+  })
+  it('memoizes by function reference -- evaluates once across repeated calls', async () => {
+    let calls = 0
+    const by = () => {
+      calls++
+      return 'heron'
+    }
+    await resolveBranchKey({ by })
+    await resolveBranchKey({ by })
+    await resolveBranchKey({ by })
+    assert.equal(calls, 1)
+  })
+  it('does not share cache across distinct function references', async () => {
+    let calls = 0
+    const makeBy = () => () => {
+      calls++
+      return 'heron'
+    }
+    await resolveBranchKey({ by: makeBy() })
+    await resolveBranchKey({ by: makeBy() })
+    assert.equal(calls, 2)
+  })
+  it('rejects an empty (or whitespace-only) key', async () => {
+    await assert.rejects(() => resolveBranchKey({ by: () => '   ' }))
+  })
+  it('rejects a key containing a slash', async () => {
+    await assert.rejects(() => resolveBranchKey({ by: () => 'foo/bar' }))
+  })
+  it('rejects a key of ..', async () => {
+    await assert.rejects(() => resolveBranchKey({ by: () => '..' }))
+  })
+  it('rejects reserved segment names, including ~default', async () => {
+    await assert.rejects(() => resolveBranchKey({ by: () => '~by~' }))
+    await assert.rejects(() => resolveBranchKey({ by: () => '~~' }))
+    await assert.rejects(() => resolveBranchKey({ by: () => '~default' }))
+  })
+})
+
+describe('resolveSowSource', () => {
+  it('returns the plain path unchanged when branchKey is null (no by)', () => {
+    const meadow = { path: '~/.zshrc' }
+    const source = resolveSowSource(meadow, null)
+    assert.equal(source.from, fixSourceControlPath('~/.zshrc'))
+    assert.equal(source.usingDefault, false)
+  })
+  it('routes to ~default and flags usingDefault when branchKey is undefined', () => {
+    const meadow = { path: '~/.gitconfig' }
+    const source = resolveSowSource(meadow, undefined)
+    assert.equal(source.from, fixSourceControlPath('~/.gitconfig', undefined))
+    assert.ok(source.from.includes(path.join('~by~', '~default')))
+    assert.equal(source.usingDefault, true)
+  })
+  it('reports exists: false when nothing is on disk for a given key', () => {
+    const meadow = { path: '~/.nonexistent-for-test' }
+    const source = resolveSowSource(meadow, 'nobody-has-gathered-this-key')
+    assert.equal(source.from, fixSourceControlPath('~/.nonexistent-for-test', 'nobody-has-gathered-this-key'))
+    assert.equal(source.usingDefault, false)
+    assert.equal(source.exists, false)
+  })
+})
+
+describe('stripLocalSuffix', () => {
+  it('strips a trailing .local', () => {
+    assert.equal(stripLocalSuffix('macbook.local'), 'macbook')
+  })
+  it('leaves non-.local names untouched', () => {
+    assert.equal(stripLocalSuffix('heron'), 'heron')
   })
 })
 
@@ -109,5 +214,14 @@ describe('findMeadowForPath', () => {
     const match = findMeadowForPath(target, meadows)
     assert.ok(match)
     assert.equal(match.meadow.path, '~/')
+  })
+
+  it('strips a ~by~/<key>/ prefix on reverse mapping, for any key (transparent read)', () => {
+    const mirrorPath = fixSourceControlPath(path.join(home, '.config/nvim/init.lua'), 'some-other-host')
+    const match = findMeadowForPath(mirrorPath, meadows)
+    assert.ok(match)
+    assert.equal(match.meadow.path, '~/.config/nvim')
+    assert.equal(match.absolute, path.join(home, '.config/nvim/init.lua'))
+    assert.equal(match.foreignBranchKey, 'some-other-host')
   })
 })

--- a/till.js
+++ b/till.js
@@ -14,15 +14,32 @@ export const meadows = [
   { path: '~/.zshrc' },
 
   // copy in a file, but only on linux
-  { 
-    if: () => linux
-    path: '~/.zshrc' 
+  {
+    if: () => linux,
+    path: '~/.zshrc'
+  },
+
+  // copy in a file, but split by a resolved key ("by") -- e.g. per-host.
+  // Each key's variant lives side by side in the mirror under
+  // meadows/~by~/<key>/, so switching hosts never overwrites another
+  // host's variant. If by() returns undefined (e.g. an unlisted host
+  // falling out of a lookup table), sow reads a shared '~default' variant
+  // instead, when one exists -- gather never writes there. NOT a secrecy
+  // mechanism -- every key's variant is still committed to the same shared
+  // repo; use \`filter\` (e.g. '!*-tokens.json') to keep something out of
+  // the mirror entirely.
+  {
+    path: '~/.gitconfig',
+    by: () => hostname(),
   },
 
   // copy in a folder, but exclude subfolders
   {
     path: '~/some/folder',
     filter: [
+      // required to work
+      '**/**',
+
       // folders need !Folder (for the directory itself) and !Folder/** (for it's files)
       // if you're using git to store these, you can skip the directory ignore
 
@@ -34,7 +51,7 @@ export const meadows = [
       '!**/this_folder/**',
     ]
   },
-])
+]
 `.trim()
 
   try {


### PR DESCRIPTION
## Summary

- Meadows can now declare `by: () => key | undefined | Promise<...>` to keep more than one variant of the same tracked path (e.g. `~/.gitconfig`) committed side by side, one per resolved key -- most commonly per host. Each key's variant lands in its own untouched corner of the mirror under `meadows/~by~/<key>/`, so gathering on one host never overwrites another host's already-committed copy.
- `wildflower gather` and `wildflower sow` only ever read or write the current host's own resolved key, even when a foreign host's mirror path is explicitly named as the target -- this is the safety-critical property the whole feature depends on, since a bug here would mean `sow` could deploy the wrong host's file onto the wrong machine. `wildflower path` and `wildflower diff`, by contrast, are read-only and transparently honor whichever key is named explicitly, so a foreign host's variant can be inspected or diffed against the local file without switching hosts.
- If `by()` resolves to `undefined` (or `null`) instead of a string, that's read as "this meadow branches, but there's no identity for this host right now." `sow` falls back to reading a shared, reserved `~by~/~default/` subtree when one exists (always logging that it did so); `gather` refuses outright, since there's nowhere safe for it to write. `~default` is populated only by hand, never by any wildflower command, and is a reserved segment name so an ordinary `by()` resolver can never target it directly.
- Along the way, fixed a real pre-existing bug in `gather`'s and `sow`'s wholesale loops: a throwing `if` condition previously propagated out of the entire loop and aborted every meadow after it, not just its own. Both loops now isolate `if`/`by` failures per-meadow. Also fixed two unrelated pre-existing syntax bugs in `till.js`'s generated sample `meadows.mjs` (a missing comma, a stray unmatched paren) that would throw a `SyntaxError` for a new user running `gather` before editing the file.

## Test plan

- [x] `npm run test:coverage` -- all 50 tests pass, including new unit tests for the pure helpers (`resolveBranchKey`, `resolveSowSource`, `fixSourceControlPath`'s branch-key threading, `stripLocalSuffix`, `findMeadowForPath`'s foreign-key stripping) and filesystem-level tests proving gather/sow only ever touch the current host's own subtree and that gather never writes to `~default`.
- [x] Manual CLI smoke test simulating four hosts via `VALLEY_PATH`/`HOME`/`SIM_HOST` overrides: two hosts gather different content for the same meadow without collision; a third host's `sow` refuses cleanly when nothing has been gathered for its key yet; `~default` seeded by hand and picked up by a fourth host's `sow` (with an explicit log line, not a silent substitution); `gather` refuses for that fourth host and never touches `~default`.
- [x] Manual CLI check that `wildflower path` and `wildflower diff` can resolve/inspect a foreign host's committed variant when named explicitly, while a targeted `wildflower gather` naming a foreign host's mirror path as its target still only writes to the current host's own subtree, leaving the foreign host's committed content untouched.